### PR TITLE
(en/anilist): Add new filter and update years to 2026

### DIFF
--- a/src/en/anilist/build.gradle
+++ b/src/en/anilist/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    extKmkVersionCode = 0
+    extKmkVersionCode = 1
     extName = 'AniList'
     extClass = '.AniList'
     extVersionCode = 9

--- a/src/en/anilist/src/eu/kanade/tachiyomi/animeextension/en/anilist/AniList.kt
+++ b/src/en/anilist/src/eu/kanade/tachiyomi/animeextension/en/anilist/AniList.kt
@@ -147,6 +147,10 @@ class AniList : ConfigurableAnimeSource, AnimeHttpSource() {
                 put("status", params.status)
             }
 
+            if (params.country.isNotBlank()) {
+                put("countryOfOrigin", params.country)
+            }
+
             put("type", "ANIME")
             if (!preferences.allowAdult) put("isAdult", false)
         }

--- a/src/en/anilist/src/eu/kanade/tachiyomi/animeextension/en/anilist/Filters.kt
+++ b/src/en/anilist/src/eu/kanade/tachiyomi/animeextension/en/anilist/Filters.kt
@@ -48,6 +48,7 @@ object Filters {
     class SeasonFilter : QueryPartFilter("Season", AniListFiltersData.SEASON_LIST)
     class FormatFilter : CheckBoxFilterList("Format", AniListFiltersData.FORMAT_LIST)
     class StatusFilter : QueryPartFilter("Airing Status", AniListFiltersData.STATUS_LIST)
+    class CountryFilter : QueryPartFilter("Country Of Origin", AniListFiltersData.COUNTRY_LIST)
 
     class SortFilter : AnimeFilter.Sort(
         "Sort",
@@ -61,6 +62,7 @@ object Filters {
         SeasonFilter(),
         FormatFilter(),
         StatusFilter(),
+        CountryFilter(),
         SortFilter(),
     )
 
@@ -70,6 +72,7 @@ object Filters {
         val season: String = "",
         val format: List<String> = emptyList(),
         val status: String = "",
+        val country: String = "",
         val sort: String = "",
     )
 
@@ -82,6 +85,7 @@ object Filters {
             filters.asQueryPart<SeasonFilter>(),
             filters.parseCheckboxList<FormatFilter>(AniListFiltersData.FORMAT_LIST),
             filters.asQueryPart<StatusFilter>(),
+            filters.asQueryPart<CountryFilter>(),
             filters.getSort<SortFilter>(),
         )
     }
@@ -110,6 +114,8 @@ object Filters {
 
         val YEAR_LIST = arrayOf(
             Pair("<Select>", ""),
+            Pair("2026", "2026"),
+            Pair("2025", "2025"),
             Pair("2024", "2024"),
             Pair("2023", "2023"),
             Pair("2022", "2022"),
@@ -221,6 +227,14 @@ object Filters {
             Pair("Finished", "FINISHED"),
             Pair("Not Yet Aired", "NOT_YET_RELEASED"),
             Pair("Cancelled", "CANCELLED"),
+        )
+
+        val COUNTRY_LIST = arrayOf(
+            Pair("<Select>", ""),
+            Pair("Japan", "JP"),
+            Pair("South Korea", "KR"),
+            Pair("China", "CN"),
+            Pair("Taiwan", "TW"),
         )
 
         val SORT_LIST = arrayOf(

--- a/src/en/anilist/src/eu/kanade/tachiyomi/animeextension/en/anilist/Queries.kt
+++ b/src/en/anilist/src/eu/kanade/tachiyomi/animeextension/en/anilist/Queries.kt
@@ -16,6 +16,7 @@ query (
     %seasonYear: Int,
     %season: MediaSeason,
     %format: [MediaFormat],
+    %countryOfOrigin: CountryCode,
 ) {
     Page (page: %page, perPage: %perPage) {
         pageInfo {
@@ -32,6 +33,7 @@ query (
             seasonYear: %seasonYear,
             season: %season,
             format_in: %format,
+            countryOfOrigin: %countryOfOrigin,
         ) {
             id
             title {


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

## Summary by Sourcery

Add new filtering capabilities to the AniList anime extension, including country of origin filter and updated year range

New Features:
- Added country of origin filter for anime search
- Extended year filter range to include 2025 and 2026

Enhancements:
- Updated GraphQL query to support country of origin filtering
- Expanded filter options in the AniList extension