### PR TITLE
fix buzzheavier (#969)

### DIFF
--- a/lib/buzzheavier-extractor/src/main/java/eu/kanade/tachiyomi/lib/buzzheavierextractor/BuzzheavierExtractor.kt
+++ b/lib/buzzheavier-extractor/src/main/java/eu/kanade/tachiyomi/lib/buzzheavierextractor/BuzzheavierExtractor.kt
@@ -32,7 +32,9 @@ class BuzzheavierExtractor(
             add("Referer", url)
         }.build()
 
-        val path = client.newCall(GET("$url/download", dlHeaders)).execute().headers["hx-redirect"].orEmpty()
+        val path = client.newCall(
+            GET("https://${httpUrl.host}/$id/download", dlHeaders)
+        ).execute().headers["hx-redirect"].orEmpty()
 
         return if (path.isNotEmpty()) {
             val videoUrl = if (path.startsWith("http")) path else "https://${httpUrl.host}$path"

--- a/src/all/hikari/build.gradle
+++ b/src/all/hikari/build.gradle
@@ -2,7 +2,7 @@ ext {
     extKmkVersionCode = 0
     extName = 'Hikari'
     extClass = '.Hikari'
-    extVersionCode = 17
+    extVersionCode = 18
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/hikari/src/eu/kanade/tachiyomi/animeextension/all/hikari/Hikari.kt
+++ b/src/all/hikari/src/eu/kanade/tachiyomi/animeextension/all/hikari/Hikari.kt
@@ -40,11 +40,6 @@ class Hikari : AnimeHttpSource(), ConfigurableAnimeSource {
 
     override val supportsLatest = true
 
-    override fun headersBuilder() = super.headersBuilder().apply {
-        add("Origin", baseUrl)
-        add("Referer", "$baseUrl/")
-    }
-
     private val preferences by lazy {
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
     }


### PR DESCRIPTION
## Summary by Sourcery

Fix Buzzheavier extractor and Hikari source by updating download URL handling and removing unnecessary headers

Bug Fixes:
- Corrected Buzzheavier extractor download URL generation
- Removed redundant headers in Hikari source