### PR TITLE
(all/hikari) provider selection and hiki mirrors (#970)

### DIFF
--- a/src/all/hikari/build.gradle
+++ b/src/all/hikari/build.gradle
@@ -2,7 +2,7 @@ ext {
     extKmkVersionCode = 0
     extName = 'Hikari'
     extClass = '.Hikari'
-    extVersionCode = 18
+    extVersionCode = 19
 }
 
 apply from: "$rootDir/common.gradle"


### PR DESCRIPTION
* Update Hikari.kt

* Update build.gradle

(cherry picked from commit 5d902c35764062e25ec000c2090d2a6df0687d28)

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

## Summary by Sourcery

Enhance Hikari anime extension with provider selection and mirror configuration options

New Features:
- Add ability to enable/disable specific video providers
- Introduce Hiki provider mirror selection

Enhancements:
- Implement flexible video provider filtering
- Add configurable Hiki mirror options