### PR TITLE
AnimePahe: Reverse episode order (#940)

### DIFF
--- a/src/en/animepahe/build.gradle
+++ b/src/en/animepahe/build.gradle
@@ -2,7 +2,7 @@ ext {
     extKmkVersionCode = 1
     extName = 'AnimePahe'
     extClass = '.AnimePahe'
-    extVersionCode = 30
+    extVersionCode = 31
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
+++ b/src/en/animepahe/src/eu/kanade/tachiyomi/animeextension/en/animepahe/AnimePahe.kt
@@ -162,6 +162,7 @@ class AnimePahe : ConfigurableAnimeSource, AnimeHttpSource() {
                 episode.name = "Episode ${index + 1}"
                 episode
             }
+            .reversed()
     }
 
     private fun parseEpisodePage(episodes: List<EpisodeDto>, animeSession: String): MutableList<SEpisode> {


### PR DESCRIPTION
* Update AnimePahe.kt

* Update build.gradle

* Update AnimePahe.kt

Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

## Summary by Sourcery

Reverse the episode order for AnimePahe anime extension

Enhancements:
- Modify episode list to display episodes in reversed order

Chores:
- Increment extension version code