### PR TITLE
Fix playlist-utils (#980)

### DIFF
--- a/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
@@ -10,7 +10,6 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.internal.commonEmptyHeaders
 import java.io.File
-import kotlin.math.abs
 
 class PlaylistUtils(private val client: OkHttpClient, private val headers: Headers = commonEmptyHeaders) {
 
@@ -154,7 +153,6 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
                 ?.let { resolution ->
                     val standardQuality = Regex("""[xX](\d+)""").find(resolution)
                         ?.groupValues?.get(1)
-                        ?.let(::stnQuality)
 
                     if (!standardQuality.isNullOrBlank()) {
                         "$standardQuality ($resolution)"
@@ -366,13 +364,6 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
     }
 
     // ============================= Utilities ==============================
-
-    private fun stnQuality(quality: String): String {
-        val intQuality = quality.trim().toInt()
-        val standardQualities = listOf(144, 240, 360, 480, 720, 1080)
-        val result =  standardQualities.minByOrNull { abs(it - intQuality) } ?: quality
-        return "${result}p"
-    }
 
     private fun cleanSubtitleData(matchResult: MatchResult): String {
         val lineCount = matchResult.groupValues[1].count { it == '\n' }


### PR DESCRIPTION
* dont standardize qualities for everything

* bump all ext depending directly or indirectly on playlist-utils

## Summary by Sourcery

Relocate video quality standardization logic from `playlist-utils` to `universal-extractor` and adjust its application.

Bug Fixes:
- Remove automatic standardization of video quality strings from HLS resolution in `playlist-utils` unlicensed_usage=True

Enhancements:
- Relocate the function for standardizing video quality strings (e.g., '718' to '720p') to `universal-extractor` unlicensed_usage=True
- Apply quality standardization in `universal-extractor` when generating HLS video names unlicensed_usage=True