### PR TITLE
(ar/witanime) Domain Change (#985)

### DIFF
--- a/src/ar/witanime/build.gradle
+++ b/src/ar/witanime/build.gradle
@@ -2,7 +2,7 @@ ext {
     extKmkVersionCode = 1
     extName = 'WIT ANIME'
     extClass = '.WitAnime'
-    extVersionCode = 52
+    extVersionCode = 53
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/witanime/src/eu/kanade/tachiyomi/animeextension/ar/witanime/WitAnime.kt
+++ b/src/ar/witanime/src/eu/kanade/tachiyomi/animeextension/ar/witanime/WitAnime.kt
@@ -30,7 +30,7 @@ class WitAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "WIT ANIME"
 
-    override val baseUrl = "https://witanime.pics"
+    override val baseUrl = "https://witanime.cyou"
 
     override val lang = "ar"
 


### PR DESCRIPTION
* Update WitAnime.kt

* Update build.gradle

## Summary by Sourcery

Update WitAnime extension domain to a new URL

Enhancements:
- Update base URL from witanime.pics to witanime.cyou

Chores:
- Increment extension version code