### PR TITLE
feat(deps): update aniyomi-lib version to support related-animes

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.
 gradle-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin_version" }
 gradle-kotlinter = { module = "org.jmailen.gradle:kotlinter-gradle", version = "3.15.0" }
 
-aniyomi-lib = { module = "com.github.komikku-app:aniyomi-extensions-lib", version = "e34cab74" }
+aniyomi-lib = { module = "com.github.komikku-app:aniyomi-extensions-lib", version = "af857426f5" }
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin_version" }
 kotlin-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "serialization_version" }


### PR DESCRIPTION
## Summary by Sourcery

Update the aniyomi-lib dependency to a newer version to support related-animes functionality

New Features:
- Add support for related-animes through library version update

Chores:
- Bump aniyomi-extensions-lib from commit e34cab74 to af857426f5