### PR TITLE
feat(en/allanime): add Similar shows & fix cover

### DIFF
--- a/src/en/allanime/build.gradle
+++ b/src/en/allanime/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    extKmkVersionCode = 1
+    extKmkVersionCode = 2
     extName = 'AllAnime'
     extClass = '.AllAnime'
     extVersionCode = 37

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -182,7 +182,7 @@ class AllAnime : ConfigurableAnimeSource, AnimeHttpSource() {
         val slugTime = if (time.isNotEmpty()) "-st-$time" else time
         val siteUrl = preferences.siteUrl
 
-        return "$siteUrl/anime/$id/$slug$slugTime"
+        return "$siteUrl/bangumi/$id"
     }
 
     override fun animeDetailsParse(response: Response): SAnime {
@@ -481,7 +481,7 @@ class AllAnime : ConfigurableAnimeSource, AnimeHttpSource() {
         )
 
         private const val PREF_SITE_DOMAIN_KEY = "preferred_site_domain"
-        private const val PREF_SITE_DOMAIN_DEFAULT = "https://allanime.to"
+        private const val PREF_SITE_DOMAIN_DEFAULT = "https://allmanga.to"
 
         private const val PREF_DOMAIN_KEY = "preferred_domain"
         private const val PREF_DOMAIN_DEFAULT = "https://api.allanime.day"

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -25,6 +25,7 @@ import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.util.parallelCatchingFlatMap
 import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.toJsonString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -99,8 +100,8 @@ class AllAnime : ConfigurableAnimeSource, AnimeHttpSource() {
         val data = buildJsonObject {
             putJsonObject("variables") {
                 putJsonObject("search") {
-                    put("allowAdult", false)
-                    put("allowUnknown", false)
+                    put("allowAdult", true)
+                    put("allowUnknown", true)
                 }
                 put("limit", PAGE_SIZE)
                 put("page", page)
@@ -124,8 +125,8 @@ class AllAnime : ConfigurableAnimeSource, AnimeHttpSource() {
                 putJsonObject("variables") {
                     putJsonObject("search") {
                         put("query", query)
-                        put("allowAdult", false)
-                        put("allowUnknown", false)
+                        put("allowAdult", true)
+                        put("allowUnknown", true)
                     }
                     put("limit", PAGE_SIZE)
                     put("page", page)
@@ -139,8 +140,8 @@ class AllAnime : ConfigurableAnimeSource, AnimeHttpSource() {
             val data = buildJsonObject {
                 putJsonObject("variables") {
                     putJsonObject("search") {
-                        put("allowAdult", false)
-                        put("allowUnknown", false)
+                        put("allowAdult", true)
+                        put("allowUnknown", true)
                         if (filters.season != "all") put("season", filters.season)
                         if (filters.releaseYear != "all") put("year", filters.releaseYear.toInt())
                         if (filters.genres != "all") {
@@ -162,6 +163,28 @@ class AllAnime : ConfigurableAnimeSource, AnimeHttpSource() {
     }
 
     override fun searchAnimeParse(response: Response): AnimesPage = parseAnime(response)
+
+    override fun relatedAnimeListRequest(anime: SAnime): Request {
+        val genres = anime.genre?.split(", ").orEmpty().toJsonString()
+        val data = buildJsonObject {
+            putJsonObject("variables") {
+                putJsonObject("search") {
+                    put("allowAdult", true)
+                    put("allowUnknown", true)
+                    put("genres", json.decodeFromString(genres))
+                }
+                put("limit", PAGE_SIZE)
+                put("page", 1)
+                put("translationType", preferences.subPref)
+            }
+            put("query", SEARCH_QUERY)
+        }
+        return buildPost(data)
+    }
+
+    override fun relatedAnimeListParse(response: Response): List<SAnime> {
+        return parseAnime(response).animes
+    }
 
     // ============================== Filters ===============================
 

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -165,7 +165,9 @@ class AllAnime : ConfigurableAnimeSource, AnimeHttpSource() {
     override fun searchAnimeParse(response: Response): AnimesPage = parseAnime(response)
 
     override fun relatedAnimeListRequest(anime: SAnime): Request {
-        val genres = anime.genre?.split(", ").orEmpty().toJsonString()
+        val genres = anime.genre?.split(",").orEmpty()
+            .map { it.trim() }
+            .toJsonString()
         val data = buildJsonObject {
             putJsonObject("variables") {
                 putJsonObject("search") {

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -86,7 +86,7 @@ class AllAnime : ConfigurableAnimeSource, AnimeHttpSource() {
                     "eng" -> it.anyCard!!.englishName ?: it.anyCard.name
                     else -> it.anyCard!!.nativeName ?: it.anyCard.name
                 }
-                thumbnail_url = it.anyCard.thumbnail
+                thumbnail_url = thumbnailUrl(it.anyCard.thumbnail)
                 url = "${it.anyCard._id}<&sep>${it.anyCard.slugTime ?: ""}<&sep>${it.anyCard.name.slugify()}"
             }
         }
@@ -475,12 +475,20 @@ class AllAnime : ConfigurableAnimeSource, AnimeHttpSource() {
                     "eng" -> ani.englishName ?: ani.name
                     else -> ani.nativeName ?: ani.name
                 }
-                thumbnail_url = ani.thumbnail
+                thumbnail_url = thumbnailUrl(ani.thumbnail)
                 url = "${ani._id}<&sep>${ani.slugTime ?: ""}<&sep>${ani.name.slugify()}"
             }
         }
 
         return AnimesPage(animeList, animeList.size == PAGE_SIZE)
+    }
+
+    private fun thumbnailUrl(url: String): String {
+        return if (url.startsWith("https://")) {
+            THUMBNAIL_PROXY.format(url.removePrefix("https://"))
+        } else {
+            THUMBNAIL_PROXY_SUB.format(url)
+        }
     }
 
     private fun String.containsAny(keywords: List<String>): Boolean {
@@ -504,6 +512,9 @@ class AllAnime : ConfigurableAnimeSource, AnimeHttpSource() {
             "filemoon",
             "streamwish",
         )
+
+        private const val THUMBNAIL_PROXY = "https://wp.youtube-anime.com/%s?w=250"
+        private const val THUMBNAIL_PROXY_SUB = "https://wp.youtube-anime.com/aln.youtube-anime.com/%s?w=250"
 
         private const val PREF_SITE_DOMAIN_KEY = "preferred_site_domain"
         private const val PREF_SITE_DOMAIN_DEFAULT = "https://allmanga.to"

--- a/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
+++ b/src/en/allanime/src/eu/kanade/tachiyomi/animeextension/en/allanime/AllAnime.kt
@@ -46,7 +46,9 @@ class AllAnime : ConfigurableAnimeSource, AnimeHttpSource() {
 
     override val name = "AllAnime"
 
-    override val baseUrl by lazy { preferences.baseUrl }
+    override val baseUrl by lazy { "${preferences.siteUrl}/anime" }
+
+    private val apiUrl by lazy { preferences.apiUrl }
 
     override val lang = "en"
 
@@ -259,12 +261,12 @@ class AllAnime : ConfigurableAnimeSource, AnimeHttpSource() {
             add("Accept", "*/*")
             add("Content-Length", payload.contentLength().toString())
             add("Content-Type", payload.contentType().toString())
-            add("Host", baseUrl.toHttpUrl().host)
+            add("Host", apiUrl.toHttpUrl().host)
             add("Origin", siteUrl)
-            add("Referer", "$baseUrl/")
+            add("Referer", "$apiUrl/")
         }.build()
 
-        return POST("$baseUrl/api", headers = postHeaders, body = payload)
+        return POST("$apiUrl/api", headers = postHeaders, body = payload)
     }
 
     private val allAnimeExtractor by lazy { AllAnimeExtractor(client, headers, preferences.siteUrl) }
@@ -411,12 +413,12 @@ class AllAnime : ConfigurableAnimeSource, AnimeHttpSource() {
             add("Accept", "*/*")
             add("Content-Length", payload.contentLength().toString())
             add("Content-Type", payload.contentType().toString())
-            add("Host", baseUrl.toHttpUrl().host)
+            add("Host", apiUrl.toHttpUrl().host)
             add("Origin", siteUrl)
-            add("Referer", "$baseUrl/")
+            add("Referer", "$apiUrl/")
         }.build()
 
-        return POST("$baseUrl/api", headers = postHeaders, body = payload)
+        return POST("$apiUrl/api", headers = postHeaders, body = payload)
     }
 
     data class Server(
@@ -656,7 +658,7 @@ class AllAnime : ConfigurableAnimeSource, AnimeHttpSource() {
     private val SharedPreferences.subPref
         get() = getString(PREF_SUB_KEY, PREF_SUB_DEFAULT)!!
 
-    private val SharedPreferences.baseUrl
+    private val SharedPreferences.apiUrl
         get() = getString(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)!!
 
     private val SharedPreferences.siteUrl


### PR DESCRIPTION
- add Similar shows
- fix thumbnail URL
- fix site/manga URL (webview)
- refactor baseUrl vs. apiUrl

## Summary by Sourcery

Add similar shows support, refactor URL configuration and request headers, fix cover thumbnails and detail URLs, adjust search filters, and update version code.

New Features:
- Add API calls and parsing for fetching similar shows

Bug Fixes:
- Fix thumbnail URL generation by proxying images
- Correct anime detail links to use /bangumi/{id} path
- Correct default site domain preference to https://allmanga.to

Enhancements:
- Refactor base site and API URLs into separate preferences and update request headers
- Enable allowAdult and allowUnknown flags for comprehensive search

Build:
- Bump extKmkVersionCode to 2