### PR TITLE
fix(all/streamingunity): Fix trailer name nullable and add trailer links

### DIFF
--- a/src/all/streamingcommunity/build.gradle
+++ b/src/all/streamingcommunity/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    extKmkVersionCode = 1
+    extKmkVersionCode = 2
     extName = 'StreamingCommunity'
     extClass = '.StreamingCommunityFactory'
     extVersionCode = 6

--- a/src/all/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/all/streamingcommunity/Dto.kt
+++ b/src/all/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/all/streamingcommunity/Dto.kt
@@ -119,7 +119,7 @@ data class SingleShowResponse(
                 val is_hd: Int, // 1
                 val youtube_id: String, // "0IqOJgtS5nw"
             ) {
-                fun getName() = name?.takeIf { it.isNotBlank() } ?: "Trailer"
+                val displayName: String get() = name?.takeIf { it.isNotBlank() } ?: "Trailer"
             }
 
             @Serializable
@@ -156,10 +156,7 @@ data class SingleShowResponse(
                         .let { if (it.isNotBlank()) append("\n\n").append(intl["cast"]).append(": $it\n") }
                     imdb_id?.let { append("\n[IMDB](https://www.imdb.com/title/$it)") }
                     tmdb_id?.let { append("\n[TMDB](https://www.themoviedb.org/$type/$it)") }
-                    trailers.forEach {
-                        val trailerName = it.getName()
-                        append("\n[$trailerName](https://www.youtube.com/watch?v=${it.youtube_id})")
-                    }
+                    trailers.forEach { append("\n[${it.displayName}](https://www.youtube.com/watch?v=${it.youtube_id})") }
                 }.toString()
 
                 description = desc

--- a/src/all/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/all/streamingcommunity/Dto.kt
+++ b/src/all/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/all/streamingcommunity/Dto.kt
@@ -113,7 +113,7 @@ data class SingleShowResponse(
 
             @Serializable
             data class TrailerObject(
-                val name: String, // "Teaser Trailer"
+                val name: String?, // "Teaser Trailer"
                 val is_hd: Int, // 1
                 val youtube_id: String, // "0IqOJgtS5nw"
             )

--- a/src/all/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/all/streamingcommunity/Dto.kt
+++ b/src/all/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/all/streamingcommunity/Dto.kt
@@ -152,6 +152,7 @@ data class SingleShowResponse(
                         .let { if (it.isNotBlank()) append("\n\n").append(intl["cast"]).append(": $it\n") }
                     imdb_id?.let { append("\n[IMDB](https://www.imdb.com/title/$it)") }
                     tmdb_id?.let { append("\n[TMDB](https://www.themoviedb.org/$type/$it)") }
+                    trailers.forEach { append("\n[Trailer](https://www.youtube.com/watch?v=${it.youtube_id})") }
                 }.toString()
 
                 description = desc

--- a/src/all/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/all/streamingcommunity/Dto.kt
+++ b/src/all/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/all/streamingcommunity/Dto.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.animeextension.all.streamingcommunity
 
 import eu.kanade.tachiyomi.animesource.model.SAnime
 import eu.kanade.tachiyomi.lib.i18n.Intl
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.math.roundToInt
 
@@ -113,10 +114,13 @@ data class SingleShowResponse(
 
             @Serializable
             data class TrailerObject(
-                val name: String?, // "Teaser Trailer"
+                @SerialName("name")
+                private val name: String?, // "Teaser Trailer"
                 val is_hd: Int, // 1
                 val youtube_id: String, // "0IqOJgtS5nw"
-            )
+            ) {
+                fun getName() = name?.takeIf { it.isNotBlank() } ?: "Trailer"
+            }
 
             @Serializable
             data class ActorObject(
@@ -152,7 +156,10 @@ data class SingleShowResponse(
                         .let { if (it.isNotBlank()) append("\n\n").append(intl["cast"]).append(": $it\n") }
                     imdb_id?.let { append("\n[IMDB](https://www.imdb.com/title/$it)") }
                     tmdb_id?.let { append("\n[TMDB](https://www.themoviedb.org/$type/$it)") }
-                    trailers.forEach { append("\n[Trailer](https://www.youtube.com/watch?v=${it.youtube_id})") }
+                    trailers.forEach {
+                        val trailerName = it.getName()
+                        append("\n[$trailerName](https://www.youtube.com/watch?v=${it.youtube_id})")
+                    }
                 }.toString()
 
                 description = desc


### PR DESCRIPTION
Allow trailer names to be nullable and default to 'Trailer' when generating links. Add trailer links to the description for better visibility.

## Summary by Sourcery

Allow nullable trailer names with fallback and append trailer links to descriptions, and bump version code

Bug Fixes:
- Allow trailer names to be nullable and default to 'Trailer' when blank or missing

Enhancements:
- Include YouTube trailer links in the generated show description for better visibility

Build:
- Increment extKmkVersionCode to 2 in StreamingCommunity build config