### PR TITLE
Update Wcofun to new url https://www.wcoflix.tv/

### DIFF
--- a/src/en/wcofun/build.gradle
+++ b/src/en/wcofun/build.gradle
@@ -2,7 +2,7 @@ ext {
     extKmkVersionCode = 0
     extName = 'Wcofun'
     extClass = '.Wcofun'
-    extVersionCode = 14
+    extVersionCode = 15
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/wcofun/src/eu/kanade/tachiyomi/animeextension/en/wcofun/Wcofun.kt
+++ b/src/en/wcofun/src/eu/kanade/tachiyomi/animeextension/en/wcofun/Wcofun.kt
@@ -30,7 +30,7 @@ class Wcofun : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "Wcofun"
 
-    override val baseUrl = "https://www.wcoflix.tv/"
+    override val baseUrl = "https://www.wcoflix.tv"
 
     override val lang = "en"
 

--- a/src/en/wcofun/src/eu/kanade/tachiyomi/animeextension/en/wcofun/Wcofun.kt
+++ b/src/en/wcofun/src/eu/kanade/tachiyomi/animeextension/en/wcofun/Wcofun.kt
@@ -30,7 +30,7 @@ class Wcofun : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "Wcofun"
 
-    override val baseUrl = "https://www.wcofun.net"
+    override val baseUrl = "https://www.wcoflix.tv/"
 
     override val lang = "en"
 

--- a/src/en/wcostream/src/eu/kanade/tachiyomi/animeextension/en/wcostream/WCOStream.kt
+++ b/src/en/wcostream/src/eu/kanade/tachiyomi/animeextension/en/wcostream/WCOStream.kt
@@ -36,7 +36,7 @@ class WCOStream : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "WCOStream"
 
-    override val baseUrl = "https://m.wcostream.tv/"
+    override val baseUrl = "https://www.wcostream.tv"
 
     override val lang = "en"
 

--- a/src/en/wcostream/src/eu/kanade/tachiyomi/animeextension/en/wcostream/WCOStream.kt
+++ b/src/en/wcostream/src/eu/kanade/tachiyomi/animeextension/en/wcostream/WCOStream.kt
@@ -36,7 +36,7 @@ class WCOStream : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     override val name = "WCOStream"
 
-    override val baseUrl = "https://www.wcostream.tv"
+    override val baseUrl = "https://m.wcostream.tv/"
 
     override val lang = "en"
 


### PR DESCRIPTION
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [ ] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/aniyomi-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Bug Fixes:
- Update Wcofun extension's baseUrl to the new wcoflix.tv domain