### PR TITLE
chore(toast): Refactor "Restart Aniyomi" to "Restart App" and fix links

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,11 +2,11 @@
 
 I acknowledge that:
 
-- I have updated to the latest version of the app (stable is v0.15.2.2)
+- I have updated to the latest version of the app
 - I have updated all extensions
-- If this is an issue with the app itself, that I should be opening an issue in https://github.com/aniyomiorg/aniyomi
+- If this is an issue with the app itself, that I should be opening an issue in App's support site.
 - I have searched the existing issues for duplicates
-- For source requests, I have checked the list of existing extensions including the multi-source spreadsheet: https://aniyomi.org/extensions/
+- For source requests, I have checked the list of existing extensions including the multi-source spreadsheet: https://yuzono.github.io/extensions-aniyomi/
 
 **DELETE THIS SECTION IF YOU HAVE READ AND ACKNOWLEDGED IT**
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It might also be good to read our [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md).
 ## Disclaimer
 
 This project does not have any affiliation with the content providers available.
-This project is not affiliated with Aniyomi.
-Don't ask for help about these extensions at the official support means of Aniyomi.
+This project is not affiliated with Anikku or Aniyomi.
+Don't ask for help about these extensions at the official support means of Anikku or Aniyomi.
 
 All credits to the codebase goes to the original contributors.

--- a/lib-multisrc/zorotheme/src/eu/kanade/tachiyomi/multisrc/zorotheme/ZoroTheme.kt
+++ b/lib-multisrc/zorotheme/src/eu/kanade/tachiyomi/multisrc/zorotheme/ZoroTheme.kt
@@ -353,7 +353,7 @@ abstract class ZoroTheme(
                 val selected = newValue as String
                 val index = findIndexOfValue(selected)
                 val entry = entryValues[index] as String
-                Toast.makeText(screen.context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
+                Toast.makeText(screen.context, "Restart App to apply new setting.", Toast.LENGTH_LONG).show()
                 preferences.edit().putString(key, entry).commit()
             }
         }.also(screen::addPreference)
@@ -363,7 +363,7 @@ abstract class ZoroTheme(
             title = "Mark filler episodes"
             setDefaultValue(MARK_FILLERS_DEFAULT)
             setOnPreferenceChangeListener { _, newValue ->
-                Toast.makeText(screen.context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
+                Toast.makeText(screen.context, "Restart App to apply new setting.", Toast.LENGTH_LONG).show()
                 preferences.edit().putBoolean(key, newValue as Boolean).commit()
             }
         }.also(screen::addPreference)

--- a/src/all/animeonsen/src/eu/kanade/tachiyomi/animeextension/all/animeonsen/AnimeOnsen.kt
+++ b/src/all/animeonsen/src/eu/kanade/tachiyomi/animeextension/all/animeonsen/AnimeOnsen.kt
@@ -176,7 +176,7 @@ class AnimeOnsen : ConfigurableAnimeSource, AnimeHttpSource() {
     }
 }
 
-const val AO_USER_AGENT = "Aniyomi/app (mobile)"
+const val AO_USER_AGENT = "Aniyomi/App (mobile)"
 private const val PREF_SUB_KEY = "preferred_subLang"
 private const val PREF_SUB_TITLE = "Preferred sub language"
 const val PREF_SUB_DEFAULT = "en-US"

--- a/src/all/googledrive/src/eu/kanade/tachiyomi/animeextension/all/googledrive/GoogleDrive.kt
+++ b/src/all/googledrive/src/eu/kanade/tachiyomi/animeextension/all/googledrive/GoogleDrive.kt
@@ -670,7 +670,7 @@ class GoogleDrive : ConfigurableAnimeSource, AnimeHttpSource() {
                         preferences.edit().putString(DOMAIN_PREF_KEY, newValue as String).commit()
                     Toast.makeText(
                         screen.context,
-                        "Restart Aniyomi to apply changes",
+                        "Restart App to apply changes",
                         Toast.LENGTH_LONG,
                     ).show()
                     res

--- a/src/all/googledriveindex/src/eu/kanade/tachiyomi/animeextension/all/googledriveindex/GoogleDriveIndex.kt
+++ b/src/all/googledriveindex/src/eu/kanade/tachiyomi/animeextension/all/googledriveindex/GoogleDriveIndex.kt
@@ -704,7 +704,7 @@ class GoogleDriveIndex : ConfigurableAnimeSource, AnimeHttpSource() {
             setOnPreferenceChangeListener { _, newValue ->
                 try {
                     val res = preferences.edit().putString(DOMAIN_PREF_KEY, newValue as String).commit()
-                    Toast.makeText(screen.context, "Restart Aniyomi to apply changes", Toast.LENGTH_LONG).show()
+                    Toast.makeText(screen.context, "Restart App to apply changes", Toast.LENGTH_LONG).show()
                     res
                 } catch (e: java.lang.Exception) {
                     e.printStackTrace()

--- a/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
+++ b/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
@@ -513,7 +513,7 @@ class Jellyfin(private val suffix: String) : ConfigurableAnimeSource, AnimeHttpS
 
                 setDefaultValue(EXTRA_SOURCES_COUNT_DEFAULT)
                 setOnPreferenceChangeListener { _, _ ->
-                    Toast.makeText(screen.context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
+                    Toast.makeText(screen.context, "Restart App to apply new setting.", Toast.LENGTH_LONG).show()
                     true
                 }
             }.also(screen::addPreference)

--- a/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Utils.kt
+++ b/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Utils.kt
@@ -109,7 +109,7 @@ fun PreferenceScreen.addEditTextPreference(
                 val result = text.isBlank() || validate?.invoke(text) ?: true
 
                 if (restartRequired && result) {
-                    Toast.makeText(context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
+                    Toast.makeText(context, "Restart App to apply new setting.", Toast.LENGTH_LONG).show()
                 }
 
                 onComplete()

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
@@ -691,7 +691,7 @@ class Stremio : ConfigurableAnimeSource, AnimeHttpSource() {
                 preferences.clearCredentials()
                 preferences.clearLogin()
 
-                Toast.makeText(screen.context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_SHORT).show()
+                Toast.makeText(screen.context, "Restart App to apply new setting.", Toast.LENGTH_SHORT).show()
 
                 false
             }

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Utils.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Utils.kt
@@ -107,7 +107,7 @@ fun PreferenceScreen.addEditTextPreference(
 
                 if (result) {
                     if (restartRequired) {
-                        Toast.makeText(context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
+                        Toast.makeText(context, "Restart App to apply new setting.", Toast.LENGTH_LONG).show()
                     }
 
                     this.summary = getSummary(newValue)

--- a/src/all/subsplease/src/eu/kanade/tachiyomi/animeextension/all/subsplease/Subsplease.kt
+++ b/src/all/subsplease/src/eu/kanade/tachiyomi/animeextension/all/subsplease/Subsplease.kt
@@ -260,7 +260,7 @@ class Subsplease : ConfigurableAnimeSource, AnimeHttpSource() {
             setOnPreferenceChangeListener { _, newValue ->
                 runCatching {
                     val value = (newValue as String).trim().ifBlank { PREF_TOKEN_DEFAULT }
-                    Toast.makeText(screen.context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
+                    Toast.makeText(screen.context, "Restart App to apply new setting.", Toast.LENGTH_LONG).show()
                     preferences.edit().putString(key, value).commit()
                 }.getOrDefault(false)
             }

--- a/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/Torrentio.kt
+++ b/src/all/torrentio/src/eu/kanade/tachiyomi/animeextension/all/torrentio/Torrentio.kt
@@ -492,7 +492,7 @@ class Torrentio : ConfigurableAnimeSource, AnimeHttpSource() {
             setOnPreferenceChangeListener { _, newValue ->
                 runCatching {
                     val value = (newValue as String).trim().ifBlank { PREF_TOKEN_DEFAULT }
-                    Toast.makeText(screen.context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
+                    Toast.makeText(screen.context, "Restart App to apply new setting.", Toast.LENGTH_LONG).show()
                     preferences.edit().putString(key, value).commit()
                 }.getOrDefault(false)
             }

--- a/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/Torrentio.kt
+++ b/src/all/torrentioanime/src/eu/kanade/tachiyomi/animeextension/all/torrentioanime/Torrentio.kt
@@ -508,7 +508,7 @@ class Torrentio : ConfigurableAnimeSource, AnimeHttpSource() {
             setOnPreferenceChangeListener { _, newValue ->
                 runCatching {
                     val value = (newValue as String).trim().ifBlank { PREF_TOKEN_DEFAULT }
-                    Toast.makeText(screen.context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
+                    Toast.makeText(screen.context, "Restart App to apply new setting.", Toast.LENGTH_LONG).show()
                     preferences.edit().putString(key, value).commit()
                 }.getOrDefault(false)
             }

--- a/src/en/aniplay/src/eu/kanade/tachiyomi/animeextension/en/aniplay/AniPlay.kt
+++ b/src/en/aniplay/src/eu/kanade/tachiyomi/animeextension/en/aniplay/AniPlay.kt
@@ -444,7 +444,7 @@ class AniPlay : AniListAnimeHttpSource(), ConfigurableAnimeSource {
                 val selected = newValue as String
                 val index = findIndexOfValue(selected)
                 val entry = entryValues[index] as String
-                Toast.makeText(screen.context, "Restart Aniyomi to apply changes", Toast.LENGTH_LONG).show()
+                Toast.makeText(screen.context, "Restart App to apply changes", Toast.LENGTH_LONG).show()
                 preferences.edit().putString(key, entry).commit()
             }
         }.also(screen::addPreference)

--- a/src/en/superstream/src/eu/kanade/tachiyomi/animeextension/en/superstream/SuperStream.kt
+++ b/src/en/superstream/src/eu/kanade/tachiyomi/animeextension/en/superstream/SuperStream.kt
@@ -216,7 +216,7 @@ class SuperStream : ConfigurableAnimeSource, AnimeHttpSource() {
 
             setOnPreferenceChangeListener { _, newValue ->
                 val new = newValue as Boolean
-                Toast.makeText(screen.context, "Restart Aniyomi to apply new setting.", Toast.LENGTH_LONG).show()
+                Toast.makeText(screen.context, "Restart App to apply new setting.", Toast.LENGTH_LONG).show()
                 preferences.edit().putBoolean(key, new).commit()
             }
         }.also(screen::addPreference)

--- a/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
+++ b/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
@@ -81,7 +81,7 @@ class HiAnime : ZoroTheme(
                     val entry = entryValues[index] as String
                     Toast.makeText(
                         screen.context,
-                        "Restart Aniyomi to apply changes",
+                        "Restart App to apply changes",
                         Toast.LENGTH_LONG,
                     ).show()
                     preferences.edit().putString(key, entry).commit()


### PR DESCRIPTION
Update the terminology for restarting the application and correct some links for better navigation.

## Summary by Sourcery

Refactor toast messages and update project references for clarity

Enhancements:
- Standardize toast notifications to “Restart App” across multiple sources
- Refine AnimeOnsen user agent string to “Aniyomi/App (mobile)”

Documentation:
- Update issue template links to the app support site and updated extensions spreadsheet, and remove hardcoded version note
- Clarify project’s non-affiliation with Anikku or Aniyomi in README