### PR TITLE
fix(all/streamingunity): Update domain

### DIFF
--- a/src/all/streamingcommunity/build.gradle
+++ b/src/all/streamingcommunity/build.gradle
@@ -2,7 +2,7 @@ ext {
     extKmkVersionCode = 2
     extName = 'StreamingCommunity'
     extClass = '.StreamingCommunityFactory'
-    extVersionCode = 6
+    extVersionCode = 7
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/all/streamingcommunity/StreamingCommunity.kt
+++ b/src/all/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/all/streamingcommunity/StreamingCommunity.kt
@@ -44,7 +44,7 @@ class StreamingCommunity(override val lang: String, private val showType: String
 
     override val name = "StreamingUnity (${showType.replaceFirstChar { it.uppercaseChar() }})"
 
-    private val homepage = "https://streamingunity.to"
+    private val homepage = "https://streamingunity.bid"
     override val baseUrl = "$homepage/$lang"
     private val apiUrl = "$homepage/api"
 


### PR DESCRIPTION
Change the domain from `streamingunity.to` to `streamingunity.bid` and increment the version code in the build configuration.

## Summary by Sourcery

Update StreamingUnity extension domain to .bid and bump version code

Bug Fixes:
- Update homepage and API URL from streamingunity.to to streamingunity.bid

Build:
- Increment StreamingCommunity version code to 7