### PR TITLE
fix(deps): update okhttp monorepo to v5.0.0-alpha.16

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 agp_version = "8.2.2"
 coroutines_version = "1.8.1"
 kotlin_version = "2.0.0"
-okhttp_version = "5.0.0-alpha.14"
+okhttp_version = "5.0.0-alpha.16"
 serialization_version = "1.7.1"
 
 [libraries]
@@ -12,7 +12,7 @@ gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.
 gradle-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin_version" }
 gradle-kotlinter = { module = "org.jmailen.gradle:kotlinter-gradle", version = "3.15.0" }
 
-aniyomi-lib = { module = "com.github.komikku-app:aniyomi-extensions-lib", version = "af857426f5" }
+aniyomi-lib = { module = "com.github.komikku-app:aniyomi-extensions-lib", version = "F078000101" }
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin_version" }
 kotlin-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "serialization_version" }

--- a/lib/fastream-extractor/build.gradle.kts
+++ b/lib/fastream-extractor/build.gradle.kts
@@ -7,4 +7,5 @@ dependencies {
         exclude(group = "org.jetbrains.kotlin", module = "kotlin-stdlib-jdk8")
     }
     implementation(project(":lib:playlist-utils"))
+    implementation(project(":utils"))
 }

--- a/lib/fastream-extractor/src/main/java/eu/kanade/tachiyomi/lib/fastreamextractor/FastreamExtractor.kt
+++ b/lib/fastream-extractor/src/main/java/eu/kanade/tachiyomi/lib/fastreamextractor/FastreamExtractor.kt
@@ -6,10 +6,10 @@ import eu.kanade.tachiyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.commonEmptyHeaders
 import okhttp3.FormBody
 import okhttp3.Headers
 import okhttp3.OkHttpClient
-import okhttp3.internal.commonEmptyHeaders
 
 class FastreamExtractor(private val client: OkHttpClient, private val headers: Headers = commonEmptyHeaders) {
     private val videoHeaders by lazy {

--- a/lib/javcoverfetcher/build.gradle.kts
+++ b/lib/javcoverfetcher/build.gradle.kts
@@ -1,3 +1,7 @@
 plugins {
     id("lib-android")
 }
+
+dependencies {
+    implementation(project(":utils"))
+}

--- a/lib/javcoverfetcher/src/main/java/eu/kanade/tachiyomi/lib/javcoverfetcher/JavCoverFetcher.kt
+++ b/lib/javcoverfetcher/src/main/java/eu/kanade/tachiyomi/lib/javcoverfetcher/JavCoverFetcher.kt
@@ -8,9 +8,9 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.commonEmptyHeaders
 import okhttp3.FormBody
 import okhttp3.Request
-import okhttp3.internal.commonEmptyHeaders
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 

--- a/lib/playlist-utils/build.gradle.kts
+++ b/lib/playlist-utils/build.gradle.kts
@@ -1,3 +1,7 @@
 plugins {
     id("lib-android")
 }
+
+dependencies {
+    implementation(project(":utils"))
+}

--- a/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
@@ -5,10 +5,10 @@ import eu.kanade.tachiyomi.animesource.model.Track
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.commonEmptyHeaders
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
-import okhttp3.internal.commonEmptyHeaders
 import java.io.File
 
 class PlaylistUtils(private val client: OkHttpClient, private val headers: Headers = commonEmptyHeaders) {

--- a/lib/streamsilk-extractor/build.gradle.kts
+++ b/lib/streamsilk-extractor/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
 
 dependencies {
     implementation(project(":lib:playlist-utils"))
+    implementation(project(":utils"))
 }

--- a/lib/streamsilk-extractor/src/main/java/eu/kanade/tachiyomi/lib/streamsilkextractor/StreamSilkExtractor.kt
+++ b/lib/streamsilk-extractor/src/main/java/eu/kanade/tachiyomi/lib/streamsilkextractor/StreamSilkExtractor.kt
@@ -5,11 +5,11 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.commonEmptyHeaders
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.Headers
 import okhttp3.OkHttpClient
-import okhttp3.internal.commonEmptyHeaders
 import uy.kohesive.injekt.injectLazy
 
 class StreamSilkExtractor(private val client: OkHttpClient, private val headers: Headers = commonEmptyHeaders) {

--- a/lib/vidmoly-extractor/build.gradle.kts
+++ b/lib/vidmoly-extractor/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
 
 dependencies {
     implementation(project(":lib:playlist-utils"))
+    implementation(project(":utils"))
 }

--- a/lib/vidmoly-extractor/src/main/java/eu/kanade/tachiyomi/lib/vidmolyextractor/VidMolyExtractor.kt
+++ b/lib/vidmoly-extractor/src/main/java/eu/kanade/tachiyomi/lib/vidmolyextractor/VidMolyExtractor.kt
@@ -4,9 +4,9 @@ import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.lib.playlistutils.PlaylistUtils
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.commonEmptyHeaders
 import okhttp3.Headers
 import okhttp3.OkHttpClient
-import okhttp3.internal.commonEmptyHeaders
 
 class VidMolyExtractor(private val client: OkHttpClient, headers: Headers = commonEmptyHeaders) {
 

--- a/src/all/googledrive/build.gradle
+++ b/src/all/googledrive/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    extKmkVersionCode = 0
+    extKmkVersionCode = 1
     extName = 'Google Drive'
     extClass = '.GoogleDrive'
     extVersionCode = 16

--- a/src/all/googledrive/src/eu/kanade/tachiyomi/animeextension/all/googledrive/GoogleDrive.kt
+++ b/src/all/googledrive/src/eu/kanade/tachiyomi/animeextension/all/googledrive/GoogleDrive.kt
@@ -23,6 +23,7 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.util.asJsoup
 import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.commonEmptyRequestBody
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -30,7 +31,6 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import okhttp3.internal.commonEmptyRequestBody
 import okio.ProtocolException
 import org.jsoup.nodes.Document
 import uy.kohesive.injekt.Injekt

--- a/src/fr/anisama/build.gradle
+++ b/src/fr/anisama/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    extKmkVersionCode = 1
+    extKmkVersionCode = 2
     extName = 'AniSama'
     extClass = '.AniSama'
     extVersionCode = 13
@@ -14,4 +14,5 @@ dependencies {
     implementation(project(':lib:filemoon-extractor'))
     implementation(project(':lib:dood-extractor'))
     implementation(project(':lib:streamhidevid-extractor'))
+    implementation(project(":utils"))
 }

--- a/src/fr/anisama/build.gradle
+++ b/src/fr/anisama/build.gradle
@@ -14,5 +14,4 @@ dependencies {
     implementation(project(':lib:filemoon-extractor'))
     implementation(project(':lib:dood-extractor'))
     implementation(project(':lib:streamhidevid-extractor'))
-    implementation(project(":utils"))
 }

--- a/src/fr/anisama/src/eu/kanade/tachiyomi/animeextension/fr/anisama/extractors/VidCdnExtractor.kt
+++ b/src/fr/anisama/src/eu/kanade/tachiyomi/animeextension/fr/anisama/extractors/VidCdnExtractor.kt
@@ -3,11 +3,11 @@ package eu.kanade.tachiyomi.animeextension.fr.anisama.extractors
 import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.commonEmptyHeaders
 import kotlinx.serialization.Serializable
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
-import okhttp3.internal.commonEmptyHeaders
 
 class VidCdnExtractor(
     private val client: OkHttpClient,

--- a/utils/src/keiyoushi/utils/OkHttpExtensions.kt
+++ b/utils/src/keiyoushi/utils/OkHttpExtensions.kt
@@ -1,6 +1,8 @@
 package keiyoushi.utils
 
 import okhttp3.Headers
+import okhttp3.RequestBody.Companion.toRequestBody
+import okio.ByteString
 
 /**
  * Empty [okhttp3] headers used by the source.
@@ -15,3 +17,17 @@ import okhttp3.Headers
  */
 @Deprecated("Use newer API `Headers.EMPTY` instead", replaceWith = ReplaceWith("Headers.EMPTY"))
 val commonEmptyHeaders by lazy { Headers.Builder().build() }
+
+/**
+ * Empty [okhttp3] request body used by the source.
+ *
+ * Provides backward compatibility with the older internal `okhttp3.internal.commonEmptyRequestBody`
+ * by lazily returning an instance equivalent to [okhttp3.RequestBody.EMPTY].
+ *
+ * If app is still using [okhttp3] (ver 5.0.0-alpha.14) then even if extensions
+ * are updated to new API, the call would fail to look for actual instance.
+ *
+ * WARNING: Keep using this if various apps are still on older [okhttp3]
+ */
+@Deprecated("Use newer API `RequestBody.EMPTY` instead", replaceWith = ReplaceWith("RequestBody.EMPTY"))
+val commonEmptyRequestBody by lazy { ByteString.EMPTY.toRequestBody() }

--- a/utils/src/keiyoushi/utils/OkHttpExtensions.kt
+++ b/utils/src/keiyoushi/utils/OkHttpExtensions.kt
@@ -1,0 +1,17 @@
+package keiyoushi.utils
+
+import okhttp3.Headers
+
+/**
+ * Empty [okhttp3] headers used by the source.
+ *
+ * Provides backward compatibility with the older internal `okhttp3.internal.commonEmptyHeaders`
+ * by lazily returning an instance equivalent to [okhttp3.Headers.EMPTY].
+ *
+ * If app is still using [okhttp3] (ver 5.0.0-alpha.14) then even if extensions
+ * are updated to new API, the call would fail to look for actual instance.
+ *
+ * WARNING: Keep using this if various apps are still on older [okhttp3]
+ */
+@Deprecated("Use newer API `Headers.EMPTY` instead", replaceWith = ReplaceWith("Headers.EMPTY"))
+val commonEmptyHeaders by lazy { Headers.Builder().build() }


### PR DESCRIPTION
Upgrade the OkHttp library to the latest alpha version and introduce a new utility for common empty headers to improve code consistency across various extractors.

## Summary by Sourcery

Upgrade OkHttp to v5.0.0-alpha.16, introduce a commonEmptyHeaders utility for backward compatibility, and apply the utils module across various extractors and libraries while updating related dependency versions and extension version codes.

New Features:
- Provide a deprecated commonEmptyHeaders utility in the utils module for consistent empty header handling across sources.

Enhancements:
- Migrate extractor and playlist utility modules to use the new commonEmptyHeaders utility instead of okhttp3.internal.commonEmptyHeaders.
- Add the utils module as a dependency in JavCoverFetcher, PlaylistUtils, Fastream, StreamSilk, VidMoly, and the AniSama extension for shared utilities.

Build:
- Upgrade OkHttp monorepo dependency to v5.0.0-alpha.16.
- Update the aniyomi-extensions-lib version to F078000101.
- Bump extKmkVersionCode for the AniSama extension from 1 to 2.