### PR TITLE
fix(id/kuramanime): Update baseUrl

### DIFF
--- a/src/id/kuramanime/build.gradle
+++ b/src/id/kuramanime/build.gradle
@@ -2,7 +2,7 @@ ext {
     extKmkVersionCode = 0
     extName = 'Kuramanime'
     extClass = '.Kuramanime'
-    extVersionCode = 13
+    extVersionCode = 14
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/id/kuramanime/src/eu/kanade/tachiyomi/animeextension/id/kuramanime/Kuramanime.kt
+++ b/src/id/kuramanime/src/eu/kanade/tachiyomi/animeextension/id/kuramanime/Kuramanime.kt
@@ -25,7 +25,7 @@ import uy.kohesive.injekt.injectLazy
 class Kuramanime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     override val name = "Kuramanime"
 
-    override val baseUrl = "https://kuramanime.boo"
+    override val baseUrl = "https://v7.kuramanime.run"
 
     override val lang = "id"
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [x] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/aniyomi-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update Kuramanime extension to use the new base URL and bump its version code

Bug Fixes:
- Update baseUrl to https://v7.kuramanime.run
- Increment extVersionCode from 13 to 14