### PR TITLE
feat(streamingunity): More robust way to update domain

### DIFF
--- a/src/all/streamingcommunity/build.gradle
+++ b/src/all/streamingcommunity/build.gradle
@@ -2,7 +2,7 @@ ext {
     extKmkVersionCode = 3
     extName = 'StreamingCommunity'
     extClass = '.StreamingCommunityFactory'
-    extVersionCode = 8
+    extVersionCode = 9
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/all/streamingcommunity/StreamingCommunity.kt
+++ b/src/all/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/all/streamingcommunity/StreamingCommunity.kt
@@ -64,14 +64,15 @@ class StreamingCommunity(override val lang: String, private val showType: String
 
             while (response.isRedirect && redirectCount < maxRedirects) {
                 val newUrl = response.header("Location") ?: break
-                val redirectedDomain = newUrl.toHttpUrl().run { "$scheme://$host" }
+                val newUrlHttp = newUrl.toHttpUrl()
+                val redirectedDomain = newUrlHttp.run { "$scheme://$host" }
                 if (redirectedDomain != homepage) {
                     preferences.edit().putString(PREF_CUSTOM_DOMAIN_KEY, redirectedDomain).apply()
                     apiHeadersRef.set(newApiHeader())
                     jsonHeadersRef.set(newJsonHeader())
                 }
                 response.close()
-                request = request.newBuilder().url(newUrl.toHttpUrl()).build()
+                request = request.newBuilder().url(newUrlHttp).build()
                 response = chain.proceed(request)
                 redirectCount++
             }

--- a/src/all/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/all/streamingcommunity/StreamingCommunity.kt
+++ b/src/all/streamingcommunity/src/eu/kanade/tachiyomi/animeextension/all/streamingcommunity/StreamingCommunity.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -53,19 +54,37 @@ class StreamingCommunity(override val lang: String, private val showType: String
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
     }
 
-    override val client: OkHttpClient = network.client
+    override val client: OkHttpClient = network.client.newBuilder()
+        .followRedirects(false)
+        .addInterceptor { chain ->
+            val request = chain.request()
+            val response = chain.proceed(request)
+            if (response.isRedirect) {
+                val newUrl = response.header("Location") ?: return@addInterceptor response
+                val redirectedDomain = newUrl.toHttpUrl().run { "$scheme://$host" }
+                if (redirectedDomain != homepage) {
+                    preferences.edit().putString(PREF_CUSTOM_DOMAIN_KEY, redirectedDomain).apply()
+                }
+                response.close()
+                return@addInterceptor chain.proceed(request.newBuilder().url(newUrl.toHttpUrl()).build())
+            }
+            response
+        }.build()
 
-    private val homepage by lazy {
-        val customDomain = preferences.getString(PREF_CUSTOM_DOMAIN_KEY, null)
-        if (customDomain.isNullOrBlank()) {
-            DOMAIN_DEFAULT
-        } else {
-            customDomain
+    private val homepage: String
+        get() {
+            val customDomain = preferences.getString(PREF_CUSTOM_DOMAIN_KEY, null)
+            return if (customDomain.isNullOrBlank()) {
+                DOMAIN_DEFAULT
+            } else {
+                customDomain
+            }
         }
-    }
 
-    override val baseUrl by lazy { "$homepage/$lang" }
-    private val apiUrl by lazy { "$homepage/api" }
+    override val baseUrl: String
+        get() = "$homepage/$lang"
+    private val apiUrl: String
+        get() = "$homepage/api"
 
     override val supportsLatest = true
 
@@ -76,19 +95,21 @@ class StreamingCommunity(override val lang: String, private val showType: String
         classLoader = this::class.java.classLoader!!,
     )
 
-    private val apiHeaders = headers.newBuilder()
-        .add("Host", baseUrl.toHttpUrl().host)
-        .add("Referer", baseUrl)
-        .build()
+    private val apiHeaders: Headers
+        get() = headers.newBuilder()
+            .add("Host", baseUrl.toHttpUrl().host)
+            .add("Referer", baseUrl)
+            .build()
 
-    private val jsonHeaders = headers.newBuilder()
-        .add("Host", baseUrl.toHttpUrl().host)
-        .add("Referer", baseUrl)
-        .add("Content-Type", "application/json")
-        .add("X-Requested-With", "XMLHttpRequest")
-        .add("X-Inertia", "true")
-        .add("x-inertia-version", "") // This requires an up-to-date `version`
-        .build()
+    private val jsonHeaders: Headers
+        get() = headers.newBuilder()
+            .add("Host", baseUrl.toHttpUrl().host)
+            .add("Referer", baseUrl)
+            .add("Content-Type", "application/json")
+            .add("X-Requested-With", "XMLHttpRequest")
+            .add("X-Inertia", "true")
+            .add("x-inertia-version", "") // This requires an up-to-date `version`
+            .build()
 
     private val json: Json by injectLazy()
 
@@ -460,7 +481,7 @@ class StreamingCommunity(override val lang: String, private val showType: String
     }
 
     companion object {
-        private const val DOMAIN_DEFAULT = "https://streamingunity.art"
+        private const val DOMAIN_DEFAULT = "https://streamingunity.cam"
         private const val PREF_CUSTOM_DOMAIN_KEY = "custom_domain"
 
         private val TOP10_TRENDING_REGEX = Regex("""/browse/(top10|trending)""")


### PR DESCRIPTION
## Summary by Sourcery

Enhance domain update logic by intercepting redirects in a custom OkHttp client to automatically detect and persist new domains, regenerate request headers, and enforce a redirect limit.

Enhancements:
- Replace static HTTP client with a custom client that intercepts up to 5 redirects to detect and apply domain changes dynamically.
- Convert homepage, baseUrl, and apiUrl to computed getters that respect the updated custom domain preference.
- Store API and JSON headers in AtomicReferences and regenerate them when the domain changes.

Chores:
- Update default domain from streamingunity.art to streamingunity.cam.
- Bump extension version code to 9.