### PR TITLE
feat(zh/Hanime1): Update search & parsing detail

### DIFF
--- a/src/zh/hanime1/build.gradle
+++ b/src/zh/hanime1/build.gradle
@@ -2,7 +2,7 @@ ext {
     extKmkVersionCode = 0
     extName = 'Hanime1'
     extClass = '.Hanime1'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = true
 }
 

--- a/src/zh/hanime1/src/eu/kanade/tachiyomi/animeextension/zh/hanime1/Hanime1.kt
+++ b/src/zh/hanime1/src/eu/kanade/tachiyomi/animeextension/zh/hanime1/Hanime1.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.animeextension.zh.hanime1
 
 import android.app.Application
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
@@ -19,9 +20,11 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.Cookie
@@ -65,14 +68,32 @@ class Hanime1 : AnimeHttpSource(), ConfigurableAnimeSource {
     }
 
     override fun animeDetailsParse(response: Response): SAnime {
-        val jsoup = response.asJsoup()
+        val doc = response.asJsoup()
         return SAnime.create().apply {
-            genre = jsoup.select(".single-video-tag").not("[data-toggle]").eachText().joinToString()
-            author = jsoup.select("#video-artist-name").text()
-            jsoup.select("script[type=application/ld+json]").first()?.data()?.let {
+            genre = doc.select(".single-video-tag").not("[data-toggle]").eachText().joinToString()
+            author = doc.select("#video-artist-name").text()
+            doc.select("script[type=application/ld+json]").first()?.data()?.let {
                 val info = json.decodeFromString<JsonElement>(it).jsonObject
                 title = info["name"]!!.jsonPrimitive.content
-                description = info["description"]!!.jsonPrimitive.content
+                description = info["description"]?.jsonPrimitive?.content
+                thumbnail_url = info["thumbnailUrl"]?.jsonArray?.firstOrNull()?.jsonPrimitive?.content
+            }
+            val type = doc.select("a#video-artist-name + a").text().trim()
+            if (type == "裏番" || type == "泡麵番") {
+                // Use the series cover image for bangumi entries instead of the episode image.
+                runBlocking {
+                    try {
+                        val animesPage =
+                            getSearchAnime(
+                                1,
+                                title,
+                                AnimeFilterList(GenreFilter(arrayOf("", type)).apply { state = 1 }),
+                            )
+                        thumbnail_url = animesPage.animes.firstOrNull()?.thumbnail_url
+                    } catch (e: Exception) {
+                        Log.e(name, "Failed to get bangumi cover image")
+                    }
+                }
             }
         }
     }
@@ -137,7 +158,7 @@ class Hanime1 : AnimeHttpSource(), ConfigurableAnimeSource {
 
     override fun searchAnimeParse(response: Response): AnimesPage {
         val jsoup = response.asJsoup()
-        val nodes = jsoup.select("div.search-doujin-videos.hidden-xs")
+        val nodes = jsoup.select("div.search-doujin-videos.hidden-xs:not(:has(a[target=_blank]))")
         val list = if (nodes.isNotEmpty()) {
             nodes.map {
                 SAnime.create().apply {
@@ -216,11 +237,13 @@ class Hanime1 : AnimeHttpSource(), ConfigurableAnimeSource {
         return chain.proceed(chain.request())
     }
 
+    private val scope = CoroutineScope(Dispatchers.IO)
+
     private fun updateFilters() {
         filterUpdateState = FilterUpdateState.UPDATING
         val exceptionHandler =
             CoroutineExceptionHandler { _, _ -> filterUpdateState = FilterUpdateState.FAILED }
-        CoroutineScope(Dispatchers.IO + exceptionHandler).launch {
+        scope.launch(exceptionHandler) {
             val jsoup = client.newCall(GET("$baseUrl/search")).awaitSuccess().asJsoup()
             val genreList = jsoup.select("div.genre-option div.hentai-sort-options").eachText()
             val sortList =


### PR DESCRIPTION
Enhance the search and parsing functionality in the Hanime1 extension, including improvements to genre and author extraction, and adjustments to thumbnail retrieval for specific types of content.

## Summary by Sourcery

Enhance the Hanime1 extension by improving metadata parsing and search result filtering, adjusting thumbnail retrieval for specific content types, and updating the version code.

New Features:
- Use series cover image as thumbnail for bangumi entries of types "裏番" and "泡麵番"

Enhancements:
- Safely extract description and thumbnail URL from JSON-LD metadata in anime details
- Refine search result parsing to exclude entries with external "target=_blank" links
- Consolidate filter updates under a shared IO coroutine scope

Build:
- Bump extension version code from 4 to 5