### PR TITLE
fix(gradle-build): Fix recursive call on `printDependentExtensions`

### DIFF
--- a/.github/scripts/generate-build-matrices.py
+++ b/.github/scripts/generate-build-matrices.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python3
+
+# Require Python 3.12 or higher
+
 import itertools
 import json
 import os

--- a/.github/scripts/generate-build-matrices.py
+++ b/.github/scripts/generate-build-matrices.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-# Require Python 3.12 or higher
+import sys
+assert sys.version_info >= (3, 12), "Requires Python 3.12+"
 
 import itertools
 import json

--- a/buildSrc/src/main/kotlin/Extensions.kt
+++ b/buildSrc/src/main/kotlin/Extensions.kt
@@ -25,13 +25,20 @@ fun Project.getDependents(): Set<Project> {
 }
 
 fun Project.printDependentExtensions() {
+    printDependentExtensions(mutableSetOf())
+}
+
+private fun Project.printDependentExtensions(visited: MutableSet<String>) {
+    if (path in visited) return
+    visited.add(path)
+
     getDependents().forEach { project ->
         if (project.path.startsWith(":src:")) {
             println(project.path)
         } else if (project.path.startsWith(":lib-multisrc:")) {
             project.getDependents().forEach { println(it.path) }
         } else if (project.path.startsWith(":lib:")) {
-            project.printDependentExtensions()
+            project.printDependentExtensions(visited)
         }
     }
 }

--- a/buildSrc/src/main/kotlin/Extensions.kt
+++ b/buildSrc/src/main/kotlin/Extensions.kt
@@ -1,4 +1,3 @@
-import groovy.lang.MissingPropertyException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.plugins.ExtensionAware
@@ -33,12 +32,13 @@ private fun Project.printDependentExtensions(visited: MutableSet<String>) {
     visited.add(path)
 
     getDependents().forEach { project ->
-        if (project.path.startsWith(":src:")) {
-            println(project.path)
-        } else if (project.path.startsWith(":lib-multisrc:")) {
-            project.getDependents().forEach { println(it.path) }
-        } else if (project.path.startsWith(":lib:")) {
-            project.printDependentExtensions(visited)
+        when {
+            project.path.startsWith(":src:") ->
+                println(project.path)
+            project.path.startsWith(":lib-multisrc:") ->
+                project.getDependents().forEach { println(it.path) }
+            project.path.startsWith(":lib:") ->
+                project.printDependentExtensions(visited)
         }
     }
 }


### PR DESCRIPTION
Resolve a recursive call issue in the `printDependentExtensions` function and ensure the script requires Python version 3.12 or higher.

## Summary by Sourcery

Prevent infinite recursion in Gradle extension printing and enforce Python 3.12 requirement for build matrix generation

Bug Fixes:
- Fix recursive call in printDependentExtensions by tracking visited project paths to avoid cycles

Enhancements:
- Require Python 3.12 or higher in the generate-build-matrices script