### PR TITLE
fix(gradle-build): Fix dependencies for :lib

### DIFF
--- a/.github/scripts/generate-build-matrices.py
+++ b/.github/scripts/generate-build-matrices.py
@@ -14,7 +14,7 @@ from typing import NoReturn
 
 EXTENSION_REGEX = re.compile(r"^src/(?P<lang>\w+)/(?P<extension>\w+)")
 MULTISRC_LIB_REGEX = re.compile(r"^lib-multisrc/(?P<multisrc>\w+)")
-LIB_REGEX = re.compile(r"^lib/(?P<lib>\w+)")
+LIB_REGEX = re.compile(r"^lib/(?P<lib>[\w-]+)")
 MODULE_REGEX = re.compile(r"^:src:(?P<lang>\w+):(?P<extension>\w+)$")
 CORE_FILES_REGEX = re.compile(
     r"^(buildSrc/|core/|gradle/|build\.gradle\.kts|common\.gradle|gradle\.properties|settings\.gradle\.kts|utils/)"

--- a/buildSrc/src/main/kotlin/Extensions.kt
+++ b/buildSrc/src/main/kotlin/Extensions.kt
@@ -38,7 +38,7 @@ private fun Project.printDependentExtensions(visited: MutableSet<String>) {
             project.path.startsWith(":lib-multisrc:") ->
                 project.getDependents().forEach { println(it.path) }
             project.path.startsWith(":lib:") ->
-                project.printDependentExtensions(visited)
+                project.getDependents().forEach { println(it.path) }
         }
     }
 }


### PR DESCRIPTION
Update regex for library names and modify dependency printing logic to ensure correct handling of project dependencies.