### PR TITLE
fix(gradle-build): Fix dependencies for :lib-multisrc

### DIFF
--- a/lib-multisrc/dopeflix/build.gradle.kts
+++ b/lib-multisrc/dopeflix/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 baseVersionCode = 20
 
 dependencies {
-    api(project(":lib:dood-extractor"))
-    api(project(":lib:cryptoaes"))
-    api(project(":lib:playlist-utils"))
+    implementation(project(":lib:dood-extractor"))
+    implementation(project(":lib:cryptoaes"))
+    implementation(project(":lib:playlist-utils"))
 }

--- a/lib-multisrc/wcotheme/build.gradle.kts
+++ b/lib-multisrc/wcotheme/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api(project(":lib:playlist-utils"))
+    implementation(project(":lib:playlist-utils"))
 }
 
 baseVersionCode = 1

--- a/lib-multisrc/zorotheme/build.gradle.kts
+++ b/lib-multisrc/zorotheme/build.gradle.kts
@@ -5,6 +5,6 @@ plugins {
 baseVersionCode = 6
 
 dependencies {
-    api(project(":lib:megacloud-extractor"))
-    api(project(":lib:streamtape-extractor"))
+    implementation(project(":lib:megacloud-extractor"))
+    implementation(project(":lib:streamtape-extractor"))
 }


### PR DESCRIPTION
Change dependency declarations from `api` to `implementation` for better encapsulation in the multisrc libraries.

## Summary by Sourcery

Enhancements:
- Replace 'api' with 'implementation' for project dependencies across multisrc libraries to improve encapsulation