### PR TITLE
fix(javgg): Fix server selection and improve suggestions

### DIFF
--- a/src/all/javgg/build.gradle
+++ b/src/all/javgg/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'JavGG'
     extClass = '.Javgg'
-    extVersionCode = 9
+    extVersionCode = 10
     isNsfw = true
 }
 

--- a/src/all/javgg/src/eu/kanade/tachiyomi/animeextension/all/javgg/Javgg.kt
+++ b/src/all/javgg/src/eu/kanade/tachiyomi/animeextension/all/javgg/Javgg.kt
@@ -41,6 +41,17 @@ class Javgg : ConfigurableAnimeSource, AnimeHttpSource() {
 
         private const val PREF_SERVER_KEY = "preferred_server"
         private const val PREF_SERVER_DEFAULT = "StreamWish"
+
+        /**
+         * Current servers available on the site:
+         * TB: TurboPlay
+         * VH: VidHide
+         * MD: MixDrop
+         * SW: StreamWish
+         * VG: JavGuard
+         * VO: Voe
+         * upjav: upjav
+         */
         private val SERVER_LIST = arrayOf(
             "StreamWish",
             "Voe",
@@ -132,7 +143,7 @@ class Javgg : ConfigurableAnimeSource, AnimeHttpSource() {
         val document = response.asJsoup()
         return document.select("[id*=source-player] iframe").parallelCatchingFlatMapBlocking {
             val numOpt = it.closest(".source-box")?.attr("id")?.replace("source-player-", "")
-            val serverName = document.select("[data-nume=\"$numOpt\"] .server").text()
+            val serverName = document.select("[data-nume=\"$numOpt\"] .server").attr("data-text")
             serverVideoResolver(serverName, it.attr("src"))
         }
     }


### PR DESCRIPTION
Fix the server selector and improve the suggestions feature for Suggestions.

Close #271

## Summary by Sourcery

Fix server selection logic and enhance suggestion parsing by stripping keywords, disable related animes support, update image URL regex, and bump version code

Bug Fixes:
- Correct server selection by extracting the server name from the data-text attribute

Enhancements:
- Introduce stripKeywordForRelatedAnimes to improve suggestion keyword parsing
- Disable the related animes feature by overriding supportsRelatedAnimes to false
- Refine image URL matching regex to use non-whitespace character class

Build:
- Bump extension version code to 10