### PR TITLE
feat(HiAnime): Add more domains & HD-3 server

### DIFF
--- a/lib-multisrc/zorotheme/build.gradle.kts
+++ b/lib-multisrc/zorotheme/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 6
+baseVersionCode = 7

--- a/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
+++ b/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
@@ -11,24 +11,25 @@ import eu.kanade.tachiyomi.multisrc.zorotheme.ZoroTheme
 import eu.kanade.tachiyomi.network.GET
 import okhttp3.Request
 import org.jsoup.nodes.Element
+import kotlin.getValue
 
-class HiAnime : ZoroTheme(
-    "en",
-    "HiAnime",
-    "https://hianime.to",
-    hosterNames = listOf(
-        "HD-1",
-        "HD-2",
-        "HD-3",
-        "StreamTape",
-    ),
-) {
+class HiAnime :
+    ZoroTheme(
+        "en",
+        "HiAnime",
+        "https://hianime.to",
+        hosterNames = listOf(
+            "HD-1",
+            "HD-2",
+            "HD-3",
+            "StreamTape",
+        ),
+    ) {
     override val id = 6706411382606718900L
 
     override val ajaxRoute = "/v2"
 
     private val streamtapeExtractor by lazy { StreamTapeExtractor(client) }
-
     private val megaCloudExtractor by lazy { MegaCloudExtractor(client, headers) }
 
     override val baseUrl: String

--- a/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
+++ b/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
@@ -7,6 +7,7 @@ import eu.kanade.tachiyomi.lib.megacloudextractor.MegaCloudExtractor
 import eu.kanade.tachiyomi.lib.streamtapeextractor.StreamTapeExtractor
 import eu.kanade.tachiyomi.multisrc.zorotheme.ZoroTheme
 import eu.kanade.tachiyomi.network.GET
+import extensions.utils.LazyMutable
 import extensions.utils.addListPreference
 import extensions.utils.delegate
 import okhttp3.Request
@@ -30,7 +31,7 @@ class HiAnime :
     override val ajaxRoute = "/v2"
 
     private val streamtapeExtractor by lazy { StreamTapeExtractor(client) }
-    private val megaCloudExtractor by lazy { MegaCloudExtractor(client, headers) }
+    private var megaCloudExtractor by LazyMutable { MegaCloudExtractor(client, docHeaders) }
 
     override var baseUrl: String
         by preferences.delegate(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)
@@ -78,6 +79,7 @@ class HiAnime :
         ) {
             baseUrl = it
             docHeaders = newHeaders()
+            megaCloudExtractor = MegaCloudExtractor(client, docHeaders)
         }
     }
 

--- a/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
+++ b/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
@@ -19,6 +19,7 @@ class HiAnime : ZoroTheme(
     hosterNames = listOf(
         "HD-1",
         "HD-2",
+        "HD-3",
         "StreamTape",
     ),
 ) {
@@ -53,7 +54,7 @@ class HiAnime : ZoroTheme(
                 )?.let(::listOf) ?: emptyList()
             }
 
-            "HD-1", "HD-2" -> megaCloudExtractor.getVideosFromUrl(
+            "HD-1", "HD-2", "HD-3" -> megaCloudExtractor.getVideosFromUrl(
                 server.link,
                 server.type,
                 server.name,
@@ -70,21 +71,20 @@ class HiAnime : ZoroTheme(
             ListPreference(screen.context).apply {
                 key = PREF_DOMAIN_KEY
                 title = "Preferred domain"
-                entries = arrayOf("hianime.to", "hianimez.to", "hianimez.is", "hianime.nz", "hianime.pe")
-                entryValues = arrayOf("https://hianime.to", "https://hianimez.to", "https://hianimez.is", "https://hianime.nz", "https://hianime.pe")
+                entries = DOMAIN_ENTRIES
+                entryValues = DOMAIN_VALUES
                 setDefaultValue(PREF_DOMAIN_DEFAULT)
                 summary = "%s"
 
                 setOnPreferenceChangeListener { _, newValue ->
-                    val selected = newValue as String
-                    val index = findIndexOfValue(selected)
-                    val entry = entryValues[index] as String
+                    val entry = newValue as String
                     Toast.makeText(
                         screen.context,
                         "Restart App to apply changes",
                         Toast.LENGTH_LONG,
                     ).show()
-                    preferences.edit().putString(key, entry).commit()
+                    preferences.edit().putString(key, entry).apply()
+                    true
                 }
             },
         )
@@ -92,6 +92,18 @@ class HiAnime : ZoroTheme(
 
     companion object {
         private const val PREF_DOMAIN_KEY = "preferred_domain"
-        private const val PREF_DOMAIN_DEFAULT = "https://hianime.to"
+        private val DOMAIN_ENTRIES = arrayOf(
+            "hianime.to",
+            "hianime.nz",
+            "hianime.mn",
+            "hianime.sx",
+            "hianime.is",
+            "hianime.bz",
+            "hianime.pe",
+            "hianimez.to",
+            "hianimez.is",
+        )
+        private val DOMAIN_VALUES = DOMAIN_ENTRIES.map { "https://$it" }.toTypedArray()
+        private val PREF_DOMAIN_DEFAULT = DOMAIN_VALUES[0]
     }
 }

--- a/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
+++ b/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
@@ -76,14 +76,12 @@ class HiAnime : ZoroTheme(
                 setDefaultValue(PREF_DOMAIN_DEFAULT)
                 summary = "%s"
 
-                setOnPreferenceChangeListener { _, newValue ->
-                    val entry = newValue as String
+                setOnPreferenceChangeListener { _, _ ->
                     Toast.makeText(
                         screen.context,
                         "Restart App to apply changes",
                         Toast.LENGTH_LONG,
                     ).show()
-                    preferences.edit().putString(key, entry).apply()
                     true
                 }
             },

--- a/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
+++ b/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
@@ -93,12 +93,10 @@ class HiAnime : ZoroTheme(
         private val DOMAIN_ENTRIES = arrayOf(
             "hianime.to",
             "hianime.nz",
-            "hianime.mn",
             "hianime.sx",
             "hianime.is",
             "hianime.bz",
             "hianime.pe",
-            "hianimez.to",
             "hianimez.is",
         )
         private val DOMAIN_VALUES = DOMAIN_ENTRIES.map { "https://$it" }.toTypedArray()


### PR DESCRIPTION
Introduce additional domains for user preference and add support for the HD-3 server in the HiAnime theme. Update the version code accordingly.

## Summary by Sourcery

Simplify and unify preference setup in ZoroTheme using extension functions and delegate properties, implement dynamic header regeneration, extend HiAnime with HD-3 server support and configurable domains, and bump the version code.

New Features:
- Add support for HD-3 video server in the HiAnime theme
- Allow users to select from multiple HiAnime domain endpoints via a new preference

Enhancements:
- Refactor ZoroTheme’s preference handling to use extension utilities (addListPreference, addSwitchPreference, addSetPreference) and LazyMutable delegates
- Introduce a newHeaders method for dynamic header generation when baseUrl changes

Build:
- Increment baseVersionCode to 7