### PR TITLE
Update playlist handling and quality conversion

### DIFF
--- a/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
@@ -392,7 +392,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
 
     private fun stnQuality(quality: String): String {
         val intQuality = quality.trim().toIntOrNull() ?: return quality
-        val result = STANDARD_QUALITIES.minBy { abs(it - intQuality) }
+        val result = STANDARD_QUALITIES.minByOrNull { abs(it - intQuality) } ?: quality
         return "${result}p"
     }
 

--- a/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
@@ -392,8 +392,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
 
     private fun stnQuality(quality: String): String {
         val intQuality = quality.trim().toIntOrNull() ?: return quality
-        val standardQualities = listOf(144, 240, 360, 480, 720, 1080, 1440, 2160)
-        val result = standardQualities.minBy { abs(it - intQuality) }
+        val result = STANDARD_QUALITIES.minBy { abs(it - intQuality) }
         return "${result}p"
     }
 
@@ -427,5 +426,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
 
         private val SUBTITLE_REGEX by lazy { Regex("""#EXT-X-MEDIA:TYPE=SUBTITLES.*?NAME="(.*?)".*?URI="(.*?)"""") }
         private val AUDIO_REGEX by lazy { Regex("""#EXT-X-MEDIA:TYPE=AUDIO.*?NAME="(.*?)".*?URI="(.*?)"""") }
+
+        private val STANDARD_QUALITIES = listOf(144, 240, 360, 480, 720, 1080, 1440, 2160)
     }
 }

--- a/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
@@ -31,7 +31,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
      */
     fun extractFromHls(
         playlistUrl: String,
-        referer: String = "",
+        referer: String = playlistUrl.toHttpUrl().let { "${it.scheme}://${it.host}/" },
         masterHeaders: Headers,
         videoHeaders: Headers,
         videoNameGen: (String) -> String = { quality -> quality },
@@ -72,7 +72,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
      */
     fun extractFromHls(
         playlistUrl: String,
-        referer: String = "",
+        referer: String = playlistUrl.toHttpUrl().let { "${it.scheme}://${it.host}/" },
         masterHeadersGen: (Headers, String) -> Headers = ::generateMasterHeaders,
         videoHeadersGen: (Headers, String, String) -> Headers = { baseHeaders, referer, videoUrl ->
             generateMasterHeaders(baseHeaders, referer)
@@ -228,7 +228,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
         videoNameGen: (String) -> String,
         mpdHeaders: Headers,
         videoHeaders: Headers,
-        referer: String = "",
+        referer: String = mpdUrl.toHttpUrl().let { "${it.scheme}://${it.host}/" },
         subtitleList: List<Track> = emptyList(),
         audioList: List<Track> = emptyList(),
     ): List<Video> {
@@ -269,7 +269,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
     fun extractFromDash(
         mpdUrl: String,
         videoNameGen: (String) -> String,
-        referer: String = "",
+        referer: String = mpdUrl.toHttpUrl().let { "${it.scheme}://${it.host}/" },
         mpdHeadersGen: (Headers, String) -> Headers = ::generateMasterHeaders,
         videoHeadersGen: (Headers, String, String) -> Headers = { baseHeaders, referer, videoUrl ->
             generateMasterHeaders(baseHeaders, referer)
@@ -316,7 +316,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
     fun extractFromDash(
         mpdUrl: String,
         videoNameGen: (String, String) -> String,
-        referer: String = "",
+        referer: String = mpdUrl.toHttpUrl().let { "${it.scheme}://${it.host}/" },
         mpdHeadersGen: (Headers, String) -> Headers = ::generateMasterHeaders,
         videoHeadersGen: (Headers, String, String) -> Headers = { baseHeaders, referer, videoUrl ->
             generateMasterHeaders(baseHeaders, referer)

--- a/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
@@ -38,6 +38,9 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
         videoNameGen: (String) -> String = { quality -> quality },
         subtitleList: List<Track> = emptyList(),
         audioList: List<Track> = emptyList(),
+        toStandardQuality: (String) -> String = { quality ->
+            stnQuality(quality)
+        },
     ): List<Video> {
         return extractFromHls(
             playlistUrl,
@@ -47,6 +50,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
             videoNameGen,
             subtitleList,
             audioList,
+            toStandardQuality,
         )
     }
 
@@ -81,6 +85,9 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
         videoNameGen: (String) -> String = { quality -> quality },
         subtitleList: List<Track> = emptyList(),
         audioList: List<Track> = emptyList(),
+        toStandardQuality: (String) -> String = { quality ->
+            stnQuality(quality)
+        },
     ): List<Video> {
         val masterHeaders = masterHeadersGen(headers, referer)
 
@@ -167,7 +174,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
                 ?.let { resolution ->
                     val standardQuality = Regex("""[xX](\d+)""").find(resolution)
                         ?.groupValues?.get(1)
-                        ?.let(::stnQuality)
+                        ?.let { toStandardQuality(it) }
 
                     if (!standardQuality.isNullOrBlank()) {
                         "$standardQuality ($resolution)"
@@ -385,7 +392,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
 
     private fun stnQuality(quality: String): String {
         val intQuality = quality.trim().toInt()
-        val standardQualities = listOf(144, 240, 360, 480, 720, 1080)
+        val standardQualities = listOf(144, 240, 360, 480, 720, 1080, 1440, 2160)
         val result =  standardQualities.minByOrNull { abs(it - intQuality) } ?: quality
         return "${result}p"
     }

--- a/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
@@ -163,16 +163,16 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
          *
          */
         return masterPlaylist.substringAfter(PLAYLIST_SEPARATOR).split(PLAYLIST_SEPARATOR).mapNotNull { stream ->
-            val codec = Regex("""CODECS="([^"]+)"""").find(stream)?.groupValues?.get(1)
+            val codec = CODECS_REGEX.find(stream)?.groupValues?.get(1)
             if (!codec.isNullOrBlank()) {
                 // FIXME: Why skip mp4a?
                 if (codec.startsWith("mp4a")) return@mapNotNull null
             }
 
-            val resolution = Regex("""RESOLUTION=([xX\d]+)""").find(stream)
+            val resolution = RESOLUTION_REGEX.find(stream)
                 ?.groupValues?.get(1)
                 ?.let { resolution ->
-                    val standardQuality = Regex("""[xX](\d+)""").find(resolution)
+                    val standardQuality = QUALITY_REGEX.find(resolution)
                         ?.groupValues?.get(1)
                         ?.let { toStandardQuality(it) }
 
@@ -182,7 +182,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
                         resolution
                     }
                 }
-            val bandwidth = Regex("""BANDWIDTH=(\d+)""").find(stream)
+            val bandwidth = BANDWIDTH_REGEX.find(stream)
                     ?.groupValues?.get(1)
                     ?.toLongOrNull()
             val bandwidthFormatted = bandwidth
@@ -428,6 +428,11 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
 
         private val SUBTITLE_REGEX by lazy { Regex("""#EXT-X-MEDIA:TYPE=SUBTITLES.*?NAME="(.*?)".*?URI="(.*?)"""") }
         private val AUDIO_REGEX by lazy { Regex("""#EXT-X-MEDIA:TYPE=AUDIO.*?NAME="(.*?)".*?URI="(.*?)"""") }
+
+        private val CODECS_REGEX by lazy { Regex("""CODECS="([^"]+)"""") }
+        private val RESOLUTION_REGEX by lazy { Regex("""RESOLUTION=([xX\d]+)""") }
+        private val QUALITY_REGEX by lazy { Regex("""[xX](\d+)""") }
+        private val BANDWIDTH_REGEX by lazy { Regex("""BANDWIDTH=(\d+)""") }
 
         private val STANDARD_QUALITIES = listOf(144, 240, 360, 480, 720, 1080, 1440, 2160)
     }

--- a/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
@@ -403,7 +403,13 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
 
     // ============================= Utilities ==============================
 
-    private fun String.toDefaultReferer(): String = toHttpUrl().run { "$scheme://$host/" }
+    private fun String.toDefaultReferer(): String {
+        return try {
+            toHttpUrl().run { "$scheme://$host/" }
+        } catch (e: IllegalArgumentException) {
+            ""
+        }
+    }
 
     private fun stnQuality(quality: String): String {
         val intQuality = quality.trim().toIntOrNull() ?: return quality

--- a/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
@@ -185,9 +185,9 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
             val bandwidth = Regex("""BANDWIDTH=(\d+)""").find(stream)
                     ?.groupValues?.get(1)
                     ?.toLongOrNull()
-            val bandWidthFormated = bandwidth
+            val bandwidthFormatted = bandwidth
                     ?.let(::formatBytes)
-            val streamName = listOfNotNull(resolution, bandWidthFormated).joinToString(" - ")
+            val streamName = listOfNotNull(resolution, bandwidthFormatted).joinToString(" - ")
                 .takeIf { it.isNotBlank() }
                 ?: "Video"
 
@@ -393,7 +393,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
     private fun stnQuality(quality: String): String {
         val intQuality = quality.trim().toInt()
         val standardQualities = listOf(144, 240, 360, 480, 720, 1080, 1440, 2160)
-        val result =  standardQualities.minByOrNull { abs(it - intQuality) } ?: quality
+        val result = standardQualities.minByOrNull { abs(it - intQuality) } ?: quality
         return "${result}p"
     }
 

--- a/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
@@ -32,7 +32,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
      */
     fun extractFromHls(
         playlistUrl: String,
-        referer: String = playlistUrl.toHttpUrl().let { "${it.scheme}://${it.host}/" },
+        referer: String = playlistUrl.toDefaultReferer(),
         masterHeaders: Headers,
         videoHeaders: Headers,
         videoNameGen: (String) -> String = { quality -> quality },
@@ -77,7 +77,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
      */
     fun extractFromHls(
         playlistUrl: String,
-        referer: String = playlistUrl.toHttpUrl().let { "${it.scheme}://${it.host}/" },
+        referer: String = playlistUrl.toDefaultReferer(),
         masterHeadersGen: (Headers, String) -> Headers = ::generateMasterHeaders,
         videoHeadersGen: (Headers, String, String) -> Headers = { baseHeaders, referer, videoUrl ->
             generateMasterHeaders(baseHeaders, referer)
@@ -253,7 +253,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
         videoNameGen: (String) -> String,
         mpdHeaders: Headers,
         videoHeaders: Headers,
-        referer: String = mpdUrl.toHttpUrl().let { "${it.scheme}://${it.host}/" },
+        referer: String = mpdUrl.toDefaultReferer(),
         subtitleList: List<Track> = emptyList(),
         audioList: List<Track> = emptyList(),
     ): List<Video> {
@@ -294,7 +294,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
     fun extractFromDash(
         mpdUrl: String,
         videoNameGen: (String) -> String,
-        referer: String = mpdUrl.toHttpUrl().let { "${it.scheme}://${it.host}/" },
+        referer: String = mpdUrl.toDefaultReferer(),
         mpdHeadersGen: (Headers, String) -> Headers = ::generateMasterHeaders,
         videoHeadersGen: (Headers, String, String) -> Headers = { baseHeaders, referer, videoUrl ->
             generateMasterHeaders(baseHeaders, referer)
@@ -341,7 +341,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
     fun extractFromDash(
         mpdUrl: String,
         videoNameGen: (String, String) -> String,
-        referer: String = mpdUrl.toHttpUrl().let { "${it.scheme}://${it.host}/" },
+        referer: String = mpdUrl.toDefaultReferer(),
         mpdHeadersGen: (Headers, String) -> Headers = ::generateMasterHeaders,
         videoHeadersGen: (Headers, String, String) -> Headers = { baseHeaders, referer, videoUrl ->
             generateMasterHeaders(baseHeaders, referer)
@@ -389,6 +389,10 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
     }
 
     // ============================= Utilities ==============================
+
+    private fun String.toDefaultReferer(): String {
+        return toHttpUrl().let { "${it.scheme}://${it.host}/" }
+    }
 
     private fun stnQuality(quality: String): String {
         val intQuality = quality.trim().toIntOrNull() ?: return quality

--- a/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
@@ -256,6 +256,9 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
         referer: String = mpdUrl.toDefaultReferer(),
         subtitleList: List<Track> = emptyList(),
         audioList: List<Track> = emptyList(),
+        toStandardQuality: (String) -> String = { quality ->
+            stnQuality(quality)
+        },
     ): List<Video> {
         return extractFromDash(
             mpdUrl,
@@ -267,6 +270,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
             { _, _, _ -> videoHeaders },
             subtitleList,
             audioList,
+            toStandardQuality,
         )
     }
 
@@ -301,6 +305,9 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
         },
         subtitleList: List<Track> = emptyList(),
         audioList: List<Track> = emptyList(),
+        toStandardQuality: (String) -> String = { quality ->
+            stnQuality(quality)
+        },
     ): List<Video> {
         return extractFromDash(
             mpdUrl,
@@ -312,6 +319,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
             videoHeadersGen,
             subtitleList,
             audioList,
+            toStandardQuality,
         )
     }
 
@@ -348,6 +356,9 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
         },
         subtitleList: List<Track> = emptyList(),
         audioList: List<Track> = emptyList(),
+        toStandardQuality: (String) -> String = { quality ->
+            stnQuality(quality)
+        },
     ): List<Video> {
         val mpdHeaders = mpdHeadersGen(headers, referer)
 
@@ -362,7 +373,9 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
 
         return doc.select("Representation[mimetype~=video]").map { videoSrc ->
             val bandwidth = videoSrc.attr("bandwidth")
-            val res = videoSrc.attr("height") + "p"
+            val res = videoSrc.attr("height")
+                .let(toStandardQuality)
+                .let { "$it (${videoSrc.attr("width")}x${videoSrc.attr("height")})" }
             val videoUrl = videoSrc.text()
 
             Video(

--- a/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
@@ -390,13 +390,11 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
 
     // ============================= Utilities ==============================
 
-    private fun String.toDefaultReferer(): String {
-        return toHttpUrl().let { "${it.scheme}://${it.host}/" }
-    }
+    private fun String.toDefaultReferer(): String = toHttpUrl().run { "$scheme://$host/" }
 
     private fun stnQuality(quality: String): String {
         val intQuality = quality.trim().toIntOrNull() ?: return quality
-        val result = STANDARD_QUALITIES.minByOrNull { abs(it - intQuality) } ?: quality
+        val result = STANDARD_QUALITIES.minByOrNull { abs(it - intQuality) } ?: intQuality
         return "${result}p"
     }
 

--- a/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
@@ -391,9 +391,9 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
     // ============================= Utilities ==============================
 
     private fun stnQuality(quality: String): String {
-        val intQuality = quality.trim().toInt()
+        val intQuality = quality.trim().toIntOrNull() ?: return quality
         val standardQualities = listOf(144, 240, 360, 480, 720, 1080, 1440, 2160)
-        val result = standardQualities.minByOrNull { abs(it - intQuality) } ?: quality
+        val result = standardQualities.minBy { abs(it - intQuality) }
         return "${result}p"
     }
 

--- a/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
+++ b/lib/playlist-utils/src/main/java/eu/kanade/tachiyomi/lib/playlistutils/PlaylistUtils.kt
@@ -10,6 +10,7 @@ import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import java.io.File
+import kotlin.math.abs
 
 class PlaylistUtils(private val client: OkHttpClient, private val headers: Headers = commonEmptyHeaders) {
 
@@ -166,6 +167,7 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
                 ?.let { resolution ->
                     val standardQuality = Regex("""[xX](\d+)""").find(resolution)
                         ?.groupValues?.get(1)
+                        ?.let(::stnQuality)
 
                     if (!standardQuality.isNullOrBlank()) {
                         "$standardQuality ($resolution)"
@@ -380,6 +382,13 @@ class PlaylistUtils(private val client: OkHttpClient, private val headers: Heade
     }
 
     // ============================= Utilities ==============================
+
+    private fun stnQuality(quality: String): String {
+        val intQuality = quality.trim().toInt()
+        val standardQualities = listOf(144, 240, 360, 480, 720, 1080)
+        val result =  standardQualities.minByOrNull { abs(it - intQuality) } ?: quality
+        return "${result}p"
+    }
 
     private fun cleanSubtitleData(matchResult: MatchResult): String {
         val lineCount = matchResult.groupValues[1].count { it == '\n' }

--- a/lib/universal-extractor/src/main/java/eu/kanade/tachiyomi/lib/universalextractor/UniversalExtractor.kt
+++ b/lib/universal-extractor/src/main/java/eu/kanade/tachiyomi/lib/universalextractor/UniversalExtractor.kt
@@ -18,7 +18,6 @@ import uy.kohesive.injekt.injectLazy
 import java.util.Locale
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import kotlin.math.abs
 
 class UniversalExtractor(private val client: OkHttpClient) {
     private val context: Application by injectLazy()
@@ -74,7 +73,7 @@ class UniversalExtractor(private val client: OkHttpClient) {
 
             for (quality in qualities) {
                 val modifiedUrl = resultUrl.replace("M3U8_AUTO_360", "M3U8_AUTO_$quality")
-                val videos = playlistUtils.extractFromHls(modifiedUrl, origRequestUrl, videoNameGen = { "$prefix - $host: ${stnQuality(it)} $quality" + "p" })
+                val videos = playlistUtils.extractFromHls(modifiedUrl, origRequestUrl, videoNameGen = { "$prefix - $host: $it $quality" + "p" })
 
                 if (videos.isNotEmpty()) {
                     allVideos.addAll(videos)
@@ -90,7 +89,7 @@ class UniversalExtractor(private val client: OkHttpClient) {
         return when {
             "m3u8" in resultUrl -> {
                 Log.d("UniversalExtractor", "m3u8 URL: $resultUrl")
-                playlistUtils.extractFromHls(resultUrl, origRequestUrl, videoNameGen = { "$prefix - $host: ${stnQuality(it)}" })
+                playlistUtils.extractFromHls(resultUrl, origRequestUrl, videoNameGen = { "$prefix - $host: $it" })
             }
             "mpd" in resultUrl -> {
                 Log.d("UniversalExtractor", "mpd URL: $resultUrl")
@@ -102,13 +101,6 @@ class UniversalExtractor(private val client: OkHttpClient) {
             }
             else -> emptyList()
         }
-    }
-
-    private fun stnQuality(quality: String): String {
-        val intQuality = quality.trim().toInt()
-        val standardQualities = listOf(144, 240, 360, 480, 720, 1080)
-        val result =  standardQualities.minByOrNull { abs(it - intQuality) } ?: quality
-        return "${result}p"
     }
 
     private fun String.proper(): String {

--- a/lib/universal-extractor/src/main/java/eu/kanade/tachiyomi/lib/universalextractor/UniversalExtractor.kt
+++ b/lib/universal-extractor/src/main/java/eu/kanade/tachiyomi/lib/universalextractor/UniversalExtractor.kt
@@ -73,7 +73,7 @@ class UniversalExtractor(private val client: OkHttpClient) {
 
             for (quality in qualities) {
                 val modifiedUrl = resultUrl.replace("M3U8_AUTO_360", "M3U8_AUTO_$quality")
-                val videos = playlistUtils.extractFromHls(modifiedUrl, origRequestUrl, videoNameGen = { "$prefix - $host: $it $quality" + "p" })
+                val videos = playlistUtils.extractFromHls(modifiedUrl, origRequestUrl, videoNameGen = { "$prefix - $host: $it ${quality}p" })
 
                 if (videos.isNotEmpty()) {
                     allVideos.addAll(videos)


### PR DESCRIPTION
- Sort playlists by bandwidth
- Allow custom standard-quality conversion, revert a previous quality hack (kohi-den/extensions-source#980) to restore original functionality
- Set a default referer value for playlist extraction
- Avoid null quality conversion

## Summary by Sourcery

Standardize HLS and DASH playlist extraction by sorting video variants by bandwidth, normalizing quality labels to the nearest standard values, and auto-generating referer URLs, while reverting an earlier custom quality hack in UniversalExtractor.

New Features:
- Allow callers to supply a custom standard‐quality conversion function via a new toStandardQuality parameter.

Enhancements:
- Sort extracted playlist streams by descending bandwidth before returning.
- Auto‐generate a default referer header from the playlist or MPD URL.
- Normalize parsed resolution values to the nearest standard quality using a new stnQuality method.
- Replace inline regex usage with precompiled constants for CODECS, RESOLUTION, QUALITY, and BANDWIDTH parsing.
- Remove the previous inline quality conversion hack in UniversalExtractor and restore original naming behavior.

Chores:
- Remove unused kotlin.math.abs import in UniversalExtractor.