### PR TITLE
Fixed No episode found, Fix null Synopsis, add Korean audio

### DIFF
--- a/src/en/kickassanime/build.gradle
+++ b/src/en/kickassanime/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'KickAssAnime'
     extClass = '.KickAssAnime'
-    extVersionCode = 54
+    extVersionCode = 55
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.animeextension.en.kickassanime
 
-import android.app.Application
 import android.content.SharedPreferences
 import android.util.Base64
 import androidx.preference.ListPreference
@@ -27,6 +26,7 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.parseAs
+import keiyoushi.utils.getPreferencesLazy
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -35,8 +35,6 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
 import java.util.Locale
 
@@ -52,9 +50,8 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
 
     override val supportsLatest = true
 
-    private val preferences: SharedPreferences by lazy {
-        Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
-            .clearBaseUrl()
+    private val preferences by getPreferencesLazy {
+        clearBaseUrl()
     }
 
     private val json: Json by injectLazy()

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.animeextension.en.kickassanime
 
+import android.app.Application
 import android.content.SharedPreferences
 import android.util.Base64
 import androidx.preference.ListPreference
@@ -26,7 +27,6 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.util.parseAs
-import keiyoushi.utils.getPreferencesLazy
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -35,6 +35,8 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
 import java.util.Locale
 
@@ -50,8 +52,9 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
 
     override val supportsLatest = true
 
-    private val preferences by getPreferencesLazy {
-        clearBaseUrl()
+    private val preferences: SharedPreferences by lazy {
+        Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
+            .clearBaseUrl()
     }
 
     private val json: Json by injectLazy()
@@ -89,32 +92,49 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
             .parseAs()
     }
 
+    // --- FIXED EPISODE RETRIEVAL LOGIC ---
     override suspend fun getEpisodeList(anime: SAnime): List<SEpisode> {
+        // Fetch what languages are available for this anime
         val languages = client.newCall(
             GET("$apiUrl${anime.url}/language"),
-        ).execute().parseAs<LanguagesDto>()
+        ).execute().parseAs<LanguagesDto>().result
+
         val prefLang = preferences.getString(PREF_AUDIO_LANG_KEY, PREF_AUDIO_LANG_DEFAULT)!!
-        val lang = languages.result.firstOrNull { it == prefLang } ?: PREF_AUDIO_LANG_DEFAULT
 
-        val first = getEpisodeResponse(anime, 1, lang)
-        val items = buildList {
-            addAll(first.result)
+        // Try preferred language first, then others
+        val langOrder = buildList {
+            add(prefLang)
+            addAll(languages.filter { it != prefLang })
+        }.distinct()
 
-            first.pages.drop(1).forEachIndexed { index, _ ->
-                addAll(getEpisodeResponse(anime, index + 2, lang).result)
+        var foundEpisodes: List<SEpisode>? = null
+
+        for (lang in langOrder) {
+            val firstResponse = runCatching { getEpisodeResponse(anime, 1, lang) }.getOrNull()
+            if (firstResponse == null || firstResponse.result.isEmpty()) continue
+
+            val items = buildList {
+                addAll(firstResponse.result)
+                firstResponse.pages.drop(1).forEachIndexed { idx, _ ->
+                    addAll(getEpisodeResponse(anime, idx + 2, lang).result)
+                }
+            }
+
+            if (items.isNotEmpty()) {
+                foundEpisodes = items.map {
+                    SEpisode.create().apply {
+                        name = "Ep. ${it.episode_string} - ${it.title}"
+                        url = "${anime.url}/ep-${it.episode_string}-${it.slug}"
+                        episode_number = it.episode_string.toFloatOrNull() ?: 0F
+                        scanlator = lang.getLocale()
+                    }
+                }.reversed()
+                break
             }
         }
 
-        val episodes = items.map {
-            SEpisode.create().apply {
-                name = "Ep. ${it.episode_string} - ${it.title}"
-                url = "${anime.url}/ep-${it.episode_string}-${it.slug}"
-                episode_number = it.episode_string.toFloatOrNull() ?: 0F
-                scanlator = lang.getLocale()
-            }
-        }
-
-        return episodes.reversed()
+        // If nothing was found, return empty list
+        return foundEpisodes ?: emptyList()
     }
 
     override fun episodeListParse(response: Response): List<SEpisode> {
@@ -338,7 +358,7 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
         private val PREF_DOMAIN_ENTRIES = arrayOf("kaa.to")
         private val PREF_DOMAIN_ENTRY_VALUES = PREF_DOMAIN_ENTRIES.map { "https://$it" }.toTypedArray()
         private val PREF_DOMAIN_DEFAULT = PREF_DOMAIN_ENTRY_VALUES[0]
-
+        
         private const val PREF_HOSTER_KEY = "hoster_selection"
         private const val PREF_HOSTER_TITLE = "Enable/Disable Hosts"
         private val PREF_HOSTER_DEFAULT = SERVERS.toSet()

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
@@ -326,7 +326,15 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
     }
 
     companion object {
-        private val SERVERS = arrayOf("DuckStream", "BirdStream", "VidStreaming")
+        private val SERVERS = arrayOf("VidStreaming", "DuckStream", "BirdStream")
+
+        // Add new locales to the bottom so it doesn't mess with pref indexes
+        private val LOCALE = arrayOf(
+            Pair("ja-JP", "Japanese"),
+            Pair("en-US", "English"),
+            Pair("es-ES", "Spanish (España)"),
+            Pair("ko-KR", "Korean"),
+        )
 
         const val PREFIX_SEARCH = "slug:"
 
@@ -342,21 +350,15 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
 
         private const val PREF_AUDIO_LANG_KEY = "preferred_audio_lang"
         private const val PREF_AUDIO_LANG_TITLE = "Preferred audio language"
-        private const val PREF_AUDIO_LANG_DEFAULT = "ja-JP"
+        private val PREF_AUDIO_LANG_DEFAULT = LOCALE[0].first
 
-        // Add new locales to the bottom so it doesn't mess with pref indexes
-        private val LOCALE = arrayOf(
-            Pair("en-US", "English"),
-            Pair("es-ES", "Spanish (España)"),
-            Pair("ja-JP", "Japanese"),
-        )
         private const val PREF_AUDIO_LANG_KEY_2ND = "preferred_audio_lang_2nd"
         private const val PREF_AUDIO_LANG_TITLE_2ND = "Secondary preferred audio language"
         private val PREF_AUDIO_LANG_DEFAULT_2ND = LOCALE[1].first
 
         private const val PREF_SERVER_KEY = "preferred_server"
         private const val PREF_SERVER_TITLE = "Preferred server"
-        private const val PREF_SERVER_DEFAULT = "DuckStream"
+        private val PREF_SERVER_DEFAULT = SERVERS[0]
         private val PREF_SERVER_VALUES = SERVERS
 
         private const val PREF_DOMAIN_KEY = "preferred_domain"
@@ -364,6 +366,7 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
         private val PREF_DOMAIN_ENTRIES = arrayOf("kaa.to")
         private val PREF_DOMAIN_ENTRY_VALUES = PREF_DOMAIN_ENTRIES.map { "https://$it" }.toTypedArray()
         private val PREF_DOMAIN_DEFAULT = PREF_DOMAIN_ENTRY_VALUES[0]
+
         private const val PREF_HOSTER_KEY = "hoster_selection"
         private const val PREF_HOSTER_TITLE = "Enable/Disable Hosts"
         private val PREF_HOSTER_DEFAULT = SERVERS.toSet()

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
@@ -122,14 +122,14 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
             }
             if (firstResponse == null || firstResponse.result.isEmpty()) continue
 
-            val items = run {
+            val items = runCatching {
                 val deferredPages = List(firstResponse.pages.drop(1).size) { idx ->
                     async(Dispatchers.IO) { getEpisodeResponse(anime, idx + 2, lang).result }
                 }
                 firstResponse.result + deferredPages.awaitAll().flatten()
-            }
+            }.getOrNull()
 
-            if (items.isNotEmpty()) {
+            if (!items.isNullOrEmpty()) {
                 foundEpisodes = items.map {
                     SEpisode.create().apply {
                         name = "Ep. ${it.episode_string} - ${it.title}"
@@ -334,8 +334,7 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
     companion object {
         private val SERVERS = arrayOf("VidStreaming", "DuckStream", "BirdStream")
 
-        // Add new locales to the bottom so it doesn't mess with pref indexes
-        private val LOCALE = arrayOf(
+        private val LOCALE = listOf(
             Pair("ja-JP", "Japanese"),
             Pair("en-US", "English"),
             Pair("es-ES", "Spanish (España)"),

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
@@ -381,13 +381,6 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
             entryValues = PREF_DOMAIN_ENTRY_VALUES
             setDefaultValue(PREF_DOMAIN_DEFAULT)
             summary = "%s"
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(key, entry).commit()
-            }
         }.also(screen::addPreference)
 
         SwitchPreferenceCompat(screen.context).apply {
@@ -395,11 +388,6 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
             title = PREF_USE_ENGLISH_TITLE
             summary = PREF_USE_ENGLISH_SUMMARY
             setDefaultValue(PREF_USE_ENGLISH_DEFAULT)
-
-            setOnPreferenceChangeListener { _, newValue ->
-                val new = newValue as Boolean
-                preferences.edit().putBoolean(key, new).commit()
-            }
         }.also(screen::addPreference)
 
         ListPreference(screen.context).apply {
@@ -409,12 +397,6 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
             entryValues = LOCALE.map { it.first }.toTypedArray()
             setDefaultValue(PREF_AUDIO_LANG_DEFAULT)
             summary = "%s"
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(key, entry).commit()
-            }
         }.also(screen::addPreference)
 
         ListPreference(screen.context).apply {
@@ -433,12 +415,6 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
             entryValues = PREF_QUALITY_ENTRIES
             setDefaultValue(PREF_QUALITY_DEFAULT)
             summary = "%s"
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(key, entry).commit()
-            }
         }.also(screen::addPreference)
 
         ListPreference(screen.context).apply {
@@ -448,12 +424,6 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
             entryValues = PREF_SERVER_VALUES
             setDefaultValue(PREF_SERVER_DEFAULT)
             summary = "%s"
-            setOnPreferenceChangeListener { _, newValue ->
-                val selected = newValue as String
-                val index = findIndexOfValue(selected)
-                val entry = entryValues[index] as String
-                preferences.edit().putString(key, entry).commit()
-            }
         }.also(screen::addPreference)
 
         MultiSelectListPreference(screen.context).apply {
@@ -462,11 +432,6 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
             entries = SERVERS
             entryValues = SERVERS
             setDefaultValue(PREF_HOSTER_DEFAULT)
-
-            setOnPreferenceChangeListener { _, newValue ->
-                @Suppress("UNCHECKED_CAST")
-                preferences.edit().putStringSet(key, newValue as Set<String>).commit()
-            }
         }.also(screen::addPreference)
     }
 }

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
@@ -94,7 +94,7 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
         // Fetch what languages are available for this anime
         val languages = client.newCall(
             GET("$apiUrl${anime.url}/language"),
-        ).execute().parseAs<LanguagesDto>().result
+        ).awaitSuccess().parseAs<LanguagesDto>().result
 
         val prefLang = preferences.getString(PREF_AUDIO_LANG_KEY, PREF_AUDIO_LANG_DEFAULT)!!
 

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/KickAssAnime.kt
@@ -358,7 +358,6 @@ class KickAssAnime : ConfigurableAnimeSource, AnimeHttpSource() {
         private val PREF_DOMAIN_ENTRIES = arrayOf("kaa.to")
         private val PREF_DOMAIN_ENTRY_VALUES = PREF_DOMAIN_ENTRIES.map { "https://$it" }.toTypedArray()
         private val PREF_DOMAIN_DEFAULT = PREF_DOMAIN_ENTRY_VALUES[0]
-        
         private const val PREF_HOSTER_KEY = "hoster_selection"
         private const val PREF_HOSTER_TITLE = "Enable/Disable Hosts"
         private val PREF_HOSTER_DEFAULT = SERVERS.toSet()

--- a/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/dto/KickAssAnimeDto.kt
+++ b/src/en/kickassanime/src/eu/kanade/tachiyomi/animeextension/en/kickassanime/dto/KickAssAnimeDto.kt
@@ -42,7 +42,7 @@ data class AnimeInfoDto(
     val season: String,
     val slug: String,
     val status: String,
-    val synopsis: String,
+    val synopsis: String?,
     val title: String,
     val title_en: String = "",
     val year: Int,


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/aniyomi-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Improve KickAssAnime extension by handling null synopses, adding Korean and secondary audio language support, optimizing concurrent episode fetching with language fallback, reordering default servers, and updating version code to 55

New Features:
- Add secondary audio language preference

Bug Fixes:
- Prevent null synopsis from causing errors in anime descriptions

Enhancements:
- Fetch episode pages concurrently and implement primary/secondary language fallback for episode list
- Include Korean audio locale and update language options
- Reorder default stream servers and remove redundant preference change listeners

Build:
- Bump extension version code to 55