### PR TITLE
fix(jellyfin): Fix JSON parsing

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -16,7 +16,7 @@ android {
     sourceSets {
         named("main") {
             manifest.srcFile("AndroidManifest.xml")
-            res.setSrcDirs(listOf("res"))
+            res.setSrcDirs(listOf("src/main/res"))
         }
     }
 

--- a/core/src/main/kotlin/extensions/utils/Json.kt
+++ b/core/src/main/kotlin/extensions/utils/Json.kt
@@ -40,5 +40,5 @@ fun String.toJsonBody(): RequestBody =
 /**
  * Converts the object to a JSON request body.
  */
-inline fun <reified T> T.toRequestBody(): RequestBody =
-    this.toJsonString().toJsonBody()
+inline fun <reified T> T.toRequestBody(json: Json = jsonInstance): RequestBody =
+    this.toJsonString(json).toJsonBody()

--- a/src/all/jellyfin/build.gradle
+++ b/src/all/jellyfin/build.gradle
@@ -1,12 +1,12 @@
 ext {
     extName = 'Jellyfin'
     extClass = '.JellyfinFactory'
-    extVersionCode = 25
+    extVersionCode = 26
     extNames = ["Jellyfin (1)", "Jellyfin (2)", "Jellyfin (3)"]
 }
 
 apply from: "$rootDir/common.gradle"
 
 dependencies {
-    implementation("org.apache.commons:commons-text:1.11.0")
+    implementation("org.apache.commons:commons-text:1.14.0")
 }

--- a/src/all/stremio/build.gradle
+++ b/src/all/stremio/build.gradle
@@ -8,5 +8,5 @@ ext {
 apply from: "$rootDir/common.gradle"
 
 dependencies {
-    implementation("org.apache.commons:commons-text:1.11.0")
+    implementation("org.apache.commons:commons-text:1.14.0")
 }

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
@@ -167,7 +167,7 @@ class Stremio : Source() {
         return AnimesPage(entries, data.hasMore == true)
     }
 
-    fun getLibraryAnime(
+    private fun getLibraryAnime(
         page: Int,
         query: String,
         filters: AnimeFilterList,
@@ -197,7 +197,7 @@ class Stremio : Source() {
     }
 
     // From https://github.com/Stremio/stremio-core
-    fun List<LibraryItemDto>.sortedWith(librarySort: LibrarySort): List<LibraryItemDto> {
+    private fun List<LibraryItemDto>.sortedWith(librarySort: LibrarySort): List<LibraryItemDto> {
         return sortedWith { a, b ->
             when (librarySort) {
                 LibrarySort.LAST_WATCHED -> b.state.lastWatched.compareTo(a.state.lastWatched)
@@ -231,7 +231,7 @@ class Stremio : Source() {
 
     open class UriPartFilter<T>(
         name: String,
-        val vals: Array<Pair<String, T>>,
+        private val vals: Array<Pair<String, T>>,
         state: Int = 0,
     ) : AnimeFilter.Select<String>(
         name,
@@ -243,10 +243,10 @@ class Stremio : Source() {
         }
     }
 
-    var selectedCatalogIndex: Int = 0
-    var catalogList: Array<Pair<String, CatalogDto>>? = null
+    private var selectedCatalogIndex: Int = 0
+    private var catalogList: Array<Pair<String, CatalogDto>>? = null
 
-    fun setCatalogList(addons: List<AddonDto>) {
+    private fun setCatalogList(addons: List<AddonDto>) {
         catalogList = addons.flatMap { addon ->
             addon.manifest.catalogs.map { catalog ->
                 buildString {
@@ -273,9 +273,9 @@ class Stremio : Source() {
         }.toTypedArray()
     }
 
-    var genreList: Array<Pair<String, String>>? = null
+    private var genreList: Array<Pair<String, String>>? = null
 
-    fun setGenreList(catalog: CatalogDto) {
+    private fun setGenreList(catalog: CatalogDto) {
         val genreExtra = catalog.extra?.firstOrNull { it.type == ExtraType.GENRE }
         val genreOptions = genreExtra?.options
 
@@ -294,7 +294,7 @@ class Stremio : Source() {
         }
     }
 
-    var libraryItems: List<LibraryItemDto>? = null
+    private var libraryItems: List<LibraryItemDto>? = null
     private var filtersState = FilterState.Unfetched
     private var filterAttempts = 0
 
@@ -343,7 +343,7 @@ class Stremio : Source() {
         values: Array<Pair<String, String>>,
     ) : UriPartFilter<String>("Genre", values)
 
-    var libraryTypes: List<String>? = null
+    private var libraryTypes: List<String>? = null
 
     class LibraryTypeFilter(
         values: Array<Pair<String, String>>,
@@ -618,7 +618,7 @@ class Stremio : Source() {
         |- {episodeNumber}: Episode number
         |- {seasonNumber}: Season number
         |- {description}: Episode description
-        |If you wish to place some text between curly brackets, place the escape character "${'$'}"
+        |If you wish to place some text between curly brackets, place the escape character "$"
         |before the opening curly bracket, e.g. ${'$'}{name}.
         """.trimMargin()
 
@@ -679,7 +679,7 @@ class Stremio : Source() {
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    var loginJob: Job? = null
+    private var loginJob: Job? = null
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         val logOutSummary: (String) -> String = {
             if (it.isBlank()) {


### PR DESCRIPTION
Improve JSON parsing functionality, disable library preferences on login failure, and update the commons-text library version for Jellyfin and Stremio.

## Summary by Sourcery

Improve JSON parsing across Jellyfin and Stremio extensions, tighten property access and preference logic, and update build dependencies and configurations

Bug Fixes:
- Pass JSON instance to all parseAs and toRequestBody calls for correct JSON parsing
- Disable library preference enabling until Jellyfin login succeeds

Enhancements:
- Restrict visibility of mutable properties and helper functions in Jellyfin and Stremio sources to private
- Disable library preferences on login failure

Build:
- Bump commons-text dependency to 1.14.0 in Jellyfin and Stremio modules
- Correct core modules resource directory path in build.gradle.kts