### PR TITLE
chore(gradle): Clean up unused extractor dependencies in build.gradle

### DIFF
--- a/src/en/aniwavese/build.gradle
+++ b/src/en/aniwavese/build.gradle
@@ -8,8 +8,4 @@ apply from: "$rootDir/common.gradle"
 
 dependencies {
     implementation(project(':lib:playlist-utils'))
-//    implementation(project(':lib:vidsrc-extractor'))
-//    implementation(project(':lib:filemoon-extractor'))
-//    implementation(project(':lib:mp4upload-extractor'))
-//    implementation(project(':lib:streamtape-extractor'))
 }

--- a/src/fr/wiflix/build.gradle
+++ b/src/fr/wiflix/build.gradle
@@ -13,7 +13,6 @@ dependencies {
     implementation(project(':lib:vido-extractor'))
     implementation(project(':lib:uqload-extractor'))
     implementation(project(':lib:streamdav-extractor'))
-    // ? implementation(project(':lib:waaw1-extractor'))
     implementation(project(':lib:vudeo-extractor'))
     implementation(project(':lib:streamhidevid-extractor'))
     implementation(project(':lib:upstream-extractor'))

--- a/src/tr/asyaanimeleri/build.gradle
+++ b/src/tr/asyaanimeleri/build.gradle
@@ -14,5 +14,4 @@ dependencies {
     implementation(project(":lib:sibnet-extractor"))
     implementation(project(":lib:gdriveplayer-extractor"))
     implementation(project(":lib:dood-extractor"))
-    // implementation(project(":lib:dailymotion-extractor"))
 }


### PR DESCRIPTION
which causes unnecessary version bump