### PR TITLE
fix(MegaCloud): Update decrypter URL & fix headers

### DIFF
--- a/lib/megacloud-extractor/src/main/java/eu/kanade/tachiyomi/lib/megacloudextractor/MegaCloudExtractor.kt
+++ b/lib/megacloud-extractor/src/main/java/eu/kanade/tachiyomi/lib/megacloudextractor/MegaCloudExtractor.kt
@@ -79,7 +79,7 @@ class MegaCloudExtractor(
         val m3u8: String = if (".m3u8" in encoded) {
             encoded
         } else {
-            val decodeUrl = "https://script.google.com/macros/s/AKfycbx-yHTwupis_JD0lNzoOnxYcEYeXmJZrg7JeMxYnEZnLBy5V0--UxEvP-y9txHyy1TX9Q/exec"
+            val decodeUrl = "https://script.google.com/macros/s/AKfycbxHbYHbrGMXYD2-bC-C43D3njIbU-wGiYQuJL61H4vyy6YVXkybMNNEPJNPPuZrD1gRVA/exec"
 
             val fullUrl = buildString {
                 append(decodeUrl)

--- a/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
+++ b/src/en/zoro/src/eu/kanade/tachiyomi/animeextension/en/zoro/HiAnime.kt
@@ -31,7 +31,7 @@ class HiAnime :
     override val ajaxRoute = "/v2"
 
     private val streamtapeExtractor by lazy { StreamTapeExtractor(client) }
-    private var megaCloudExtractor by LazyMutable { MegaCloudExtractor(client, docHeaders) }
+    private val megaCloudExtractor by LazyMutable { MegaCloudExtractor(client, headers) }
 
     override var baseUrl: String
         by preferences.delegate(PREF_DOMAIN_KEY, PREF_DOMAIN_DEFAULT)
@@ -79,7 +79,6 @@ class HiAnime :
         ) {
             baseUrl = it
             docHeaders = newHeaders()
-            megaCloudExtractor = MegaCloudExtractor(client, docHeaders)
         }
     }
 


### PR DESCRIPTION
Correct header handling in MegaCloudExtractor and update the server URL to dynamically use the host from the provided URL. Adjustments made to ensure proper extraction of nonce and improve overall URL management.

## Summary by Sourcery

Improve MegaCloudExtractor by dynamically resolving the server URL, correcting header usage, enhancing nonce extraction error handling, updating the decrypter endpoint, and streamline extractor initialization in the HiAnime extension

Enhancements:
- Derive MegaCloud server URL dynamically from the request URL host and update Referer header accordingly
- Add explicit error handling for invalid host and missing nonce during extraction
- Update the Google Apps Script decrypter endpoint to the new exec URL
- Use consistent headers for MegaCloudExtractor in HiAnime and prevent redundant extractor reinitialization on domain changes