### PR TITLE
fix(pt/Q1N): Fix pt/Q1N sources & more servers

### DIFF
--- a/src/pt/animesgratis/build.gradle
+++ b/src/pt/animesgratis/build.gradle
@@ -11,8 +11,8 @@ apply from: "$rootDir/common.gradle"
 dependencies {
     implementation(project(":lib:blogger-extractor"))
     implementation(project(":lib:filemoon-extractor"))
-    implementation(project(":lib:streamwish-extractor"))
     implementation(project(":lib:mixdrop-extractor"))
     implementation(project(":lib:playlist-utils"))
     implementation(project(":lib:streamtape-extractor"))
+    implementation(project(":lib:streamwish-extractor"))
 }

--- a/src/pt/animesgratis/build.gradle
+++ b/src/pt/animesgratis/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Q1N'
     themePkg = 'dooplay'
     baseUrl = 'https://q1n.net'
-    overrideVersionCode = 23
+    overrideVersionCode = 24
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/Q1N.kt
+++ b/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/Q1N.kt
@@ -56,7 +56,7 @@ class Q1N : DooPlay(
         val sheader = doc.selectFirst("div.sheader")!!
         return SAnime.create().apply {
             setUrlWithoutDomain(doc.location())
-            sheader.selectFirst("div.poster > img")!!.let {
+            sheader.selectFirst("div.poster img")!!.let {
                 thumbnail_url = it.getImageUrl()
                 title = it.attr("alt").ifEmpty {
                     sheader.selectFirst("div.data > h1")!!.text()

--- a/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/Q1N.kt
+++ b/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/Q1N.kt
@@ -192,7 +192,7 @@ class Q1N : DooPlay(
 
         return document.selectFirst("div.pag_episodes div.item > a:has(i.fa-th)")?.let {
             client.newCall(GET(it.attr("href"), headers)).execute()
-                .asJsoup()
+                .use { response -> response.asJsoup() }
         } ?: document
     }
 

--- a/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/Q1N.kt
+++ b/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/Q1N.kt
@@ -137,6 +137,7 @@ class Q1N : DooPlay(
             "noa" in name -> noaExtractor.videosFromUrl(url)
             "mdplayer" in name -> noaExtractor.videosFromUrl(url, "MDPLAYER")
             "/player/" in url -> bloggerExtractor.videosFromUrl(url, headers)
+            "blogger.com" in url -> bloggerExtractor.videosFromUrl(url, headers)
             else -> universalExtractor.videosFromUrl(url, headers)
         }
     }

--- a/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/Q1N.kt
+++ b/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/Q1N.kt
@@ -188,8 +188,8 @@ class Q1N : DooPlay(
     }
 
     private fun Element.tryGetAttr(vararg attributeKeys: String): String? {
-        val attributeKey = attributeKeys.first { hasAttr(it) }
-        return attr(attributeKey)
+        return attributeKeys.firstOrNull { hasAttr(it) }
+            ?.let { attr(it) }
     }
 
     override fun List<Video>.sort(): List<Video> {

--- a/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/Q1N.kt
+++ b/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/Q1N.kt
@@ -39,10 +39,10 @@ class Q1N : DooPlay(
 
     // ============================== Popular ===============================
     override fun popularAnimeSelector() = "div.items.featured article div.poster"
-    override fun popularAnimeRequest(page: Int) = GET("$baseUrl/a/", headers)
+    override fun popularAnimeRequest(page: Int) = GET("$baseUrl/animes/", headers)
 
     // =============================== Latest ===============================
-    override val latestUpdatesPath = "e"
+    override val latestUpdatesPath = "episodio"
 
     // =============================== Search ===============================
     override fun searchAnimeSelector() = "div.result-item article div.thumbnail > a"
@@ -136,7 +136,8 @@ class Q1N : DooPlay(
             "mixdrop" in name -> mixDropExtractor.videoFromUrl(url)
             "streamtape" in name -> streamTapeExtractor.videosFromUrl(url)
             "noa" in name -> noaExtractor.videosFromUrl(url)
-            "mdplayer" in name -> noaExtractor.videosFromUrl(url, "MDPLAYER")
+            "mdplayer" in name -> noaExtractor.videosFromUrl(url, name)
+            "/antivirus3/" in url -> noaExtractor.videosFromUrl(url, name)
             "/player/" in url -> bloggerExtractor.videosFromUrl(url, headers)
             "blogger.com" in url -> bloggerExtractor.videosFromUrl(url, headers)
             else -> universalExtractor.videosFromUrl(url, headers, name)

--- a/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/Q1N.kt
+++ b/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/Q1N.kt
@@ -128,6 +128,7 @@ class Q1N : DooPlay(
         val name = player.selectFirst("span.title")!!.text().lowercase()
         val url = getPlayerUrl(player) ?: return emptyList()
         Log.d(tag, "Fetching videos from: $url")
+
         return when {
             "ruplay" in name -> ruplayExtractor.videosFromUrl(url)
             "streamwish" in name -> streamWishExtractor.videosFromUrl(url)
@@ -138,7 +139,7 @@ class Q1N : DooPlay(
             "mdplayer" in name -> noaExtractor.videosFromUrl(url, "MDPLAYER")
             "/player/" in url -> bloggerExtractor.videosFromUrl(url, headers)
             "blogger.com" in url -> bloggerExtractor.videosFromUrl(url, headers)
-            else -> universalExtractor.videosFromUrl(url, headers)
+            else -> universalExtractor.videosFromUrl(url, headers, name)
         }
     }
 
@@ -187,7 +188,7 @@ class Q1N : DooPlay(
 
     private fun Element.tryGetAttr(vararg attributeKeys: String): String? {
         val attributeKey = attributeKeys.first { hasAttr(it) }
-        return attributeKey?.let { attr(attributeKey) }
+        return attr(attributeKey)
     }
 
     override fun List<Video>.sort(): List<Video> {

--- a/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/extractors/NoaExtractor.kt
+++ b/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/extractors/NoaExtractor.kt
@@ -25,11 +25,7 @@ class NoaExtractor(private val client: OkHttpClient, private val headers: Header
                     .split("{")
                     .drop(1)
                     .map {
-                        val label =
-                            it.substringAfter("label", "")
-                                .substringAfter(":\"")
-                                .substringBefore('"')
-                                .ifEmpty { "Default" }
+                        val label = LABEL_REGEX.find(it)?.groupValues?.get(1) ?: "Default"
                         val videoUrl = it.substringAfter("file")
                             .substringAfter(":")
                             .substringAfter('"')
@@ -41,5 +37,9 @@ class NoaExtractor(private val client: OkHttpClient, private val headers: Header
 
             else -> emptyList()
         }
+    }
+
+    companion object {
+        private val LABEL_REGEX by lazy { Regex("""label.*?:"([^"]+)"""") }
     }
 }

--- a/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/extractors/NoaExtractor.kt
+++ b/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/extractors/NoaExtractor.kt
@@ -26,9 +26,13 @@ class NoaExtractor(private val client: OkHttpClient, private val headers: Header
                     .drop(1)
                     .map {
                         val label =
-                            it.substringAfter("label").substringAfter(":\"").substringBefore('"')
+                            it.substringAfter("label", "")
+                                .substringAfter(":\"")
+                                .substringBefore('"')
+                                .ifEmpty { "Default" }
                         val videoUrl = it.substringAfter("file")
-                            .substringAfter(":\"")
+                            .substringAfter(":")
+                            .substringAfter('"')
                             .substringBefore('"')
                             .replace("\\", "")
                         Video(videoUrl, "$name - $label", videoUrl, headers)

--- a/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/extractors/NoaExtractor.kt
+++ b/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/extractors/NoaExtractor.kt
@@ -8,7 +8,7 @@ import okhttp3.OkHttpClient
 class NoaExtractor(private val client: OkHttpClient, private val headers: Headers) {
     fun videosFromUrl(url: String, name: String = "NOA"): List<Video> {
         val body = client.newCall(GET(url)).execute()
-            .body.string()
+            .use { response -> response.body.string() }
 
         return when {
             "file: jw.file" in body -> {

--- a/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/extractors/RuplayExtractor.kt
+++ b/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/extractors/RuplayExtractor.kt
@@ -7,17 +7,19 @@ import okhttp3.OkHttpClient
 
 class RuplayExtractor(private val client: OkHttpClient) {
     fun videosFromUrl(url: String): List<Video> {
-        return client.newCall(GET(url)).execute()
-            .body.string()
-            .substringAfter("Playerjs({")
-            .substringAfter("file:\"")
-            .substringBefore("\"")
-            .split(",")
-            .map {
-                val videoUrl = it.substringAfter("]")
-                val quality = it.substringAfter("[", "").substringBefore("]").ifEmpty { "Default" }
-                val headers = Headers.headersOf("Referer", videoUrl)
-                Video(videoUrl, "Ruplay - $quality", videoUrl, headers = headers)
-            }
+        return client.newCall(GET(url)).execute().use { response ->
+            response.body.string()
+                .substringAfter("Playerjs({")
+                .substringAfter("file:\"")
+                .substringBefore("\"")
+                .split(",")
+                .map {
+                    val videoUrl = it.substringAfter("]")
+                    val quality =
+                        it.substringAfter("[", "").substringBefore("]").ifEmpty { "Default" }
+                    val headers = Headers.headersOf("Referer", videoUrl)
+                    Video(videoUrl, "Ruplay - $quality", videoUrl, headers = headers)
+                }
+        }
     }
 }

--- a/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/extractors/UniversalExtractor.kt
+++ b/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/extractors/UniversalExtractor.kt
@@ -128,7 +128,7 @@ class UniversalExtractor(private val client: OkHttpClient) {
                     }
                 }
                 // Default jwplayer instance
-                playerInstance?.play();
+                try { jwplayer(0).play(); } catch {}
             }, 2500)
             """.trimIndent()
         }

--- a/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/extractors/UniversalExtractor.kt
+++ b/src/pt/animesgratis/src/eu/kanade/tachiyomi/animeextension/pt/animesgratis/extractors/UniversalExtractor.kt
@@ -25,7 +25,7 @@ class UniversalExtractor(private val client: OkHttpClient) {
     private val handler by lazy { Handler(Looper.getMainLooper()) }
 
     @SuppressLint("SetJavaScriptEnabled")
-    fun videosFromUrl(origRequestUrl: String, origRequestHeader: Headers): List<Video> {
+    fun videosFromUrl(origRequestUrl: String, origRequestHeader: Headers, name: String?): List<Video> {
         Log.d(tag, "Fetching videos from: $origRequestUrl")
         val host = origRequestUrl.toHttpUrl().host.substringBefore(".").proper()
         val latch = CountDownLatch(1)
@@ -80,18 +80,20 @@ class UniversalExtractor(private val client: OkHttpClient) {
             }
         }
 
+        val prefix = name ?: host
+
         return when {
             "m3u8" in resultUrl -> {
                 Log.d(tag, "m3u8 URL: $resultUrl")
-                playlistUtils.extractFromHls(resultUrl, origRequestUrl, videoNameGen = { "$host: $it" })
+                playlistUtils.extractFromHls(resultUrl, origRequestUrl, videoNameGen = { "$prefix: $it" })
             }
             "mpd" in resultUrl -> {
                 Log.d(tag, "mpd URL: $resultUrl")
-                playlistUtils.extractFromDash(resultUrl, { it -> "$host: $it" }, referer = origRequestUrl)
+                playlistUtils.extractFromDash(resultUrl, { it -> "$prefix: $it" }, referer = origRequestUrl)
             }
             "mp4" in resultUrl -> {
                 Log.d(tag, "mp4 URL: $resultUrl")
-                Video(resultUrl, "$host: mp4", resultUrl, Headers.headersOf("referer", origRequestUrl)).let(::listOf)
+                Video(resultUrl, "$prefix: MP4", resultUrl, Headers.headersOf("referer", origRequestUrl)).let(::listOf)
             }
             else -> emptyList()
         }
@@ -125,6 +127,8 @@ class UniversalExtractor(private val client: OkHttpClient) {
                         downloadButton.click()
                     }
                 }
+                // Default jwplayer instance
+                playerInstance?.play();
             }, 2500)
             """.trimIndent()
         }


### PR DESCRIPTION
Introduce a new M3U8 server to enhance video processing capabilities, including support for skip_initial_bytes. Fix issues related to pt/Q1N sources, ensuring popular and latest anime listings function correctly.

## Summary by Sourcery

Add a local M3U8 processing server and integrate it into the Q1N extension, refactor video extraction to use coroutines and parallel processing, fix Q1N source selectors, and improve extractor logic and versioning.

New Features:
- Introduce a NanoHTTPD-based M3U8 server library with endpoints for playlist and segment processing
- Integrate M3U8 server into Q1N to automatically handle HLS (m3u8) streams
- Refactor Q1N video extraction to coroutine-based suspend functions with parallel processing

Bug Fixes:
- Correct popular and latest anime endpoint paths in Q1N
- Fix label parsing in NoaExtractor to handle empty or custom labels

Enhancements:
- Update UniversalExtractor to accept and apply custom source names in quality labels
- Replace blocking parallel extraction with non-blocking parallelCatchingFlatMap
- Add tryGetAttr utility to safely retrieve first available attribute

Build:
- Bump Q1N overrideVersionCode to 24
- Add m3u8-server library dependency to build configuration

Documentation:
- Add user-facing README for the M3U8 server library