### PR TITLE
fix(preferences): Fix handling of null default values in preferences

### DIFF
--- a/core/src/main/kotlin/extensions/utils/Preferences.kt
+++ b/core/src/main/kotlin/extensions/utils/Preferences.kt
@@ -115,7 +115,7 @@ class LazyMutablePreference<T>(
                     is Float -> preferences.getFloat(key, default) as T
                     is Boolean -> preferences.getBoolean(key, default) as T
                     is Set<*> -> preferences.getStringSet(key, default as Set<String>) as T
-                    else -> throw IllegalArgumentException("Unsupported type: ${default?.javaClass}")
+                    else -> throw IllegalArgumentException("Unsupported type: ${default?.run { javaClass }}")
                 }
                 propValue = initializedValue
                 initializedValue
@@ -134,7 +134,7 @@ class LazyMutablePreference<T>(
                 is Float -> editor.putFloat(key, value)
                 is Boolean -> editor.putBoolean(key, value)
                 is Set<*> -> editor.putStringSet(key, value as Set<String>)
-                else -> throw IllegalArgumentException("Unsupported type: ${value?.javaClass}")
+                else -> throw IllegalArgumentException("Unsupported type: ${value?.run { javaClass }}")
             }
             editor.apply()
             propValue = value
@@ -149,7 +149,10 @@ class LazyMutablePreference<T>(
 }
 
 /**
- * Create [LazyMutablePreference] delegate
+ * Create [LazyMutablePreference] delegate.
+ *
+ * **WARNING**: Do not use this on a lib-multisrc module, as it will be initialized before the source is created,
+ * which will cause the preferences to be created with the wrong source id.
  */
 fun <T> SharedPreferences.delegate(key: String, default: T) =
     LazyMutablePreference(this, key, default)

--- a/core/src/main/kotlin/extensions/utils/Preferences.kt
+++ b/core/src/main/kotlin/extensions/utils/Preferences.kt
@@ -119,8 +119,7 @@ class LazyMutablePreference<T>(
                         null -> preferences.all[key] as T
                         else -> throw IllegalArgumentException("Unsupported type: ${default.javaClass}")
                     }
-                } catch (e: Exception) {
-                    if (e is IllegalArgumentException) throw e
+                } catch (e: ClassCastException) {
                     default
                 }
                 propValue = initializedValue

--- a/core/src/main/kotlin/extensions/utils/Preferences.kt
+++ b/core/src/main/kotlin/extensions/utils/Preferences.kt
@@ -108,16 +108,18 @@ class LazyMutablePreference<T>(
             if (localValue2 != UninitializedValue) {
                 localValue2 as T
             } else {
-                val initializedValue = when (default) {
-                    is String -> preferences.getString(key, default) as T
-                    is Int -> preferences.getInt(key, default) as T
-                    is Long -> preferences.getLong(key, default) as T
-                    is Float -> preferences.getFloat(key, default) as T
-                    is Boolean -> preferences.getBoolean(key, default) as T
-                    is Set<*> -> preferences.getStringSet(key, default as Set<String>) as T
-                    null -> preferences.getString(key, default) as T
-                    else -> throw IllegalArgumentException("Unsupported type: ${default.javaClass}")
-                }
+                val initializedValue = runCatching {
+                    when (default) {
+                        is String -> preferences.getString(key, default) as T
+                        is Int -> preferences.getInt(key, default) as T
+                        is Long -> preferences.getLong(key, default) as T
+                        is Float -> preferences.getFloat(key, default) as T
+                        is Boolean -> preferences.getBoolean(key, default) as T
+                        is Set<*> -> preferences.getStringSet(key, default as Set<String>) as T
+                        null -> preferences.all[key] as T
+                        else -> throw IllegalArgumentException("Unsupported type: ${default.javaClass}")
+                    }
+                }.getOrNull() as T
                 propValue = initializedValue
                 initializedValue
             }

--- a/core/src/main/kotlin/extensions/utils/Preferences.kt
+++ b/core/src/main/kotlin/extensions/utils/Preferences.kt
@@ -108,7 +108,7 @@ class LazyMutablePreference<T>(
             if (localValue2 != UninitializedValue) {
                 localValue2 as T
             } else {
-                val initializedValue = runCatching {
+                val initializedValue = try {
                     when (default) {
                         is String -> preferences.getString(key, default) as T
                         is Int -> preferences.getInt(key, default) as T
@@ -119,7 +119,10 @@ class LazyMutablePreference<T>(
                         null -> preferences.all[key] as T
                         else -> throw IllegalArgumentException("Unsupported type: ${default.javaClass}")
                     }
-                }.getOrNull() as T
+                } catch (e: Exception) {
+                    if (e is IllegalArgumentException) throw e
+                    default
+                }
                 propValue = initializedValue
                 initializedValue
             }

--- a/core/src/main/kotlin/extensions/utils/Preferences.kt
+++ b/core/src/main/kotlin/extensions/utils/Preferences.kt
@@ -80,7 +80,7 @@ class LazyMutable<T>(
  *
  * @param preferences Shared preferences
  * @param key Key for preference
- * @param default Default value for preference, can be `null` for `String?`
+ * @param default Default value for preference, can be `null` for `String?` or `Set<String>?`
  */
 class LazyMutablePreference<T>(
     val preferences: SharedPreferences,
@@ -161,7 +161,7 @@ class LazyMutablePreference<T>(
  * which will cause the preferences to be created with the wrong source id.
  *
  * @param key Key for preference
- * @param default Default value for preference, can be `null` for `String?`
+ * @param default Default value for preference, can be `null` for `String?` or `Set<String>?`
  */
 fun <T> SharedPreferences.delegate(key: String, default: T) =
     LazyMutablePreference(this, key, default)


### PR DESCRIPTION
Improve the handling of null default values in `LazyMutablePreference`, ensuring proper retrieval and removal of preferences. Update documentation to warn against usage in lib-multisrc modules.

## Summary by Sourcery

Fix LazyMutablePreference to properly handle null defaults and null values by supporting null retrieval as strings, removing keys when setting null, adjust exception messages, and update documentation with a warning for lib-multisrc modules.

Bug Fixes:
- Retrieve null default values correctly by returning null strings instead of throwing
- Remove preference entries when setting null values instead of failing

Enhancements:
- Use non-null javaClass in exception messages for unsupported types

Documentation:
- Add warning in delegate documentation to avoid usage in lib-multisrc modules due to initialization order issues