### PR TITLE
fix(megacloud): Fix video DTO

### DIFF
--- a/lib/megacloud-extractor/src/main/java/eu/kanade/tachiyomi/lib/megacloudextractor/MegaCloudExtractor.kt
+++ b/lib/megacloud-extractor/src/main/java/eu/kanade/tachiyomi/lib/megacloudextractor/MegaCloudExtractor.kt
@@ -77,11 +77,12 @@ class MegaCloudExtractor(
 
         val srcRes = client.newCall(GET("${megaCloudServerUrl}${SOURCES_URL}${id}&_k=${nonce}", megaCloudHeaders))
             .execute().use { it.body.string() }
-
         val data = json.decodeFromString<SourceResponseDto>(srcRes)
+
+        val key by lazy { requestNewKey() }
+
         return data.sources.map { source ->
             val encoded = source.file
-            val key = requestNewKey()
 
             val m3u8: String = if (!data.encrypted || ".m3u8" in encoded) {
                 encoded


### PR DESCRIPTION
Close #364

## Summary by Sourcery

Refactor MegaCloud extractor to support multiple video sources by updating the video DTO and extraction workflow.

Enhancements:
- Change getVideoDto to return a list of VideoDto objects and process each source sequentially
- Replace JsonElement-based sources in SourceResponseDto with a typed list of new SourceDto entries
- Update getVideosFromUrl to flatMap over all VideoDto entries for HLS stream and subtitle extraction