### PR TITLE
feat(zoro-theme): Add related animes & promotion videos and fix preferences

### DIFF
--- a/lib-multisrc/zorotheme/build.gradle.kts
+++ b/lib-multisrc/zorotheme/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 7
+baseVersionCode = 8

--- a/lib-multisrc/zorotheme/src/eu/kanade/tachiyomi/multisrc/zorotheme/ZoroTheme.kt
+++ b/lib-multisrc/zorotheme/src/eu/kanade/tachiyomi/multisrc/zorotheme/ZoroTheme.kt
@@ -285,13 +285,13 @@ abstract class ZoroTheme(
 
     override fun List<Video>.sort(): List<Video> {
         val quality = preferences.prefQuality
-        val lang = preferences.prefLang
+        val type = preferences.prefType
         val server = preferences.prefServer
 
         return this.sortedWith(
             compareByDescending<Video> { it.quality.contains(quality) }
                 .thenByDescending { it.quality.contains(server, true) }
-                .thenByDescending { it.quality.contains(lang, true) },
+                .thenByDescending { it.quality.contains(type, true) },
         )
     }
 
@@ -307,8 +307,8 @@ abstract class ZoroTheme(
     private var SharedPreferences.prefServer
         by LazyMutable { preferences.getString(PREF_SERVER_KEY, hosterNames.first())!! }
 
-    private var SharedPreferences.prefLang
-        by LazyMutable { preferences.getString(PREF_LANG_KEY, PREF_LANG_DEFAULT)!! }
+    private var SharedPreferences.prefType
+        by LazyMutable { preferences.getString(PREF_TYPE_KEY, PREF_TYPE_DEFAULT)!! }
 
     private var SharedPreferences.hostToggle
         by LazyMutable { preferences.getStringSet(PREF_HOSTER_KEY, hosterNames.toSet())!! }
@@ -327,8 +327,8 @@ abstract class ZoroTheme(
         private const val PREF_QUALITY_KEY = "preferred_quality"
         private const val PREF_QUALITY_DEFAULT = "1080"
 
-        private const val PREF_LANG_KEY = "preferred_language"
-        private const val PREF_LANG_DEFAULT = "Sub"
+        private const val PREF_TYPE_KEY = "preferred_type"
+        private const val PREF_TYPE_DEFAULT = "Sub"
 
         private const val PREF_SERVER_KEY = "preferred_server"
 
@@ -387,14 +387,14 @@ abstract class ZoroTheme(
         }
 
         screen.addListPreference(
-            key = PREF_LANG_KEY,
+            key = PREF_TYPE_KEY,
             title = "Preferred Type",
             entries = TYPES_ENTRIES,
             entryValues = TYPES_ENTRIES,
-            default = PREF_LANG_DEFAULT,
+            default = PREF_TYPE_DEFAULT,
             summary = "%s",
         ) {
-            preferences.prefLang = it
+            preferences.prefType = it
         }
 
         screen.addSetPreference(

--- a/lib-multisrc/zorotheme/src/eu/kanade/tachiyomi/multisrc/zorotheme/ZoroTheme.kt
+++ b/lib-multisrc/zorotheme/src/eu/kanade/tachiyomi/multisrc/zorotheme/ZoroTheme.kt
@@ -19,7 +19,6 @@ import extensions.utils.LazyMutable
 import extensions.utils.addListPreference
 import extensions.utils.addSetPreference
 import extensions.utils.addSwitchPreference
-import extensions.utils.delegate
 import extensions.utils.getPreferencesLazy
 import okhttp3.Headers
 import okhttp3.HttpUrl
@@ -297,25 +296,25 @@ abstract class ZoroTheme(
     }
 
     private var SharedPreferences.getTitleLang
-        by preferences.delegate(PREF_TITLE_LANG_KEY, PREF_TITLE_LANG_DEFAULT)
+        by LazyMutable { preferences.getString(PREF_TITLE_LANG_KEY, PREF_TITLE_LANG_DEFAULT)!! }
 
     private var SharedPreferences.markFiller
-        by preferences.delegate(MARK_FILLERS_KEY, MARK_FILLERS_DEFAULT)
+        by LazyMutable { preferences.getBoolean(MARK_FILLERS_KEY, MARK_FILLERS_DEFAULT) }
 
     private var SharedPreferences.prefQuality
-        by preferences.delegate(PREF_QUALITY_KEY, PREF_QUALITY_DEFAULT)
+        by LazyMutable { preferences.getString(PREF_QUALITY_KEY, PREF_QUALITY_DEFAULT)!! }
 
     private var SharedPreferences.prefServer
-        by preferences.delegate(PREF_SERVER_KEY, hosterNames.first())
+        by LazyMutable { preferences.getString(PREF_SERVER_KEY, hosterNames.first())!! }
 
     private var SharedPreferences.prefLang
-        by preferences.delegate(PREF_LANG_KEY, PREF_LANG_DEFAULT)
+        by LazyMutable { preferences.getString(PREF_LANG_KEY, PREF_LANG_DEFAULT)!! }
 
     private var SharedPreferences.hostToggle
-        by preferences.delegate(PREF_HOSTER_KEY, hosterNames.toSet())
+        by LazyMutable { preferences.getStringSet(PREF_HOSTER_KEY, hosterNames.toSet())!! }
 
     private var SharedPreferences.typeToggle
-        by preferences.delegate(PREF_TYPE_TOGGLE_KEY, PREF_TYPES_TOGGLE_DEFAULT)
+        by LazyMutable { preferences.getStringSet(PREF_TYPE_TOGGLE_KEY, PREF_TYPES_TOGGLE_DEFAULT)!! }
 
     companion object {
         private const val PREF_TITLE_LANG_KEY = "preferred_title_lang"


### PR DESCRIPTION
Update preferences handling and refactor keys. Introduce functionality to display related animes and promotion videos in the anime details.

## Summary by Sourcery

Implement promotion videos and related anime in details, refactor preference handling with LazyMutable and rename language preference to type, update video sorting accordingly, and bump version code

New Features:
- Add display of promotion videos in anime details
- Add parsing and display of related anime entries

Enhancements:
- Refactor preferences to use LazyMutable getters and rename preferred language to preferred type
- Update video sorting to use the new type preference

Build:
- Bump baseVersionCode to 8