### PR TITLE
Fix VoeExtractor to include headers

### DIFF
--- a/src/all/javgg/src/eu/kanade/tachiyomi/animeextension/all/javgg/Javgg.kt
+++ b/src/all/javgg/src/eu/kanade/tachiyomi/animeextension/all/javgg/Javgg.kt
@@ -180,7 +180,7 @@ class Javgg : ConfigurableAnimeSource, AnimeHttpSource() {
                 StreamWishExtractor(client, docHeaders).videosFromUrl(url, videoNameGen = { "StreamWish:$it" })
             }
             embedUrl.contains("vidhide") || embedUrl.contains("streamhide") || embedUrl.contains("guccihide") || embedUrl.contains("streamvid") -> StreamHideVidExtractor(client, headers).videosFromUrl(url)
-            embedUrl.contains("voe") -> VoeExtractor(client).videosFromUrl(url)
+            embedUrl.contains("voe") -> VoeExtractor(client, headers).videosFromUrl(url)
             embedUrl.contains("yourupload") || embedUrl.contains("upload") -> YourUploadExtractor(client).videoFromUrl(url, headers = headers)
             embedUrl.contains("turboplay") -> {
                 val turboDocument = client.newCall(GET(url)).execute().asJsoup()

--- a/src/all/supjav/src/eu/kanade/tachiyomi/animeextension/all/supjav/SupJav.kt
+++ b/src/all/supjav/src/eu/kanade/tachiyomi/animeextension/all/supjav/SupJav.kt
@@ -155,7 +155,7 @@ class SupJav(override val lang: String = "en") : ConfigurableAnimeSource, Parsed
     private val playlistUtils by lazy { PlaylistUtils(client, headers) }
     private val streamtapeExtractor by lazy { StreamTapeExtractor(client) }
     private val streamwishExtractor by lazy { StreamWishExtractor(client, headers) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
 
     private val protectorHeaders by lazy {
         super.headersBuilder().set("referer", "$PROTECTOR_URL/").build()
@@ -232,7 +232,7 @@ class SupJav(override val lang: String = "en") : ConfigurableAnimeSource, Parsed
     companion object {
         const val PREFIX_SEARCH = "id:"
 
-        private const val PROTECTOR_URL = "https://lk1.supremejav.com/supjav.php"
+        private const val PROTECTOR_URL = "https://lk1.supremejav.com"
 
         private val SUPPORTED_PLAYERS = setOf("TV", "FST", "VOE", "ST")
 

--- a/src/ar/anime4up/src/eu/kanade/tachiyomi/animeextension/ar/anime4up/Anime4Up.kt
+++ b/src/ar/anime4up/src/eu/kanade/tachiyomi/animeextension/ar/anime4up/Anime4Up.kt
@@ -191,7 +191,7 @@ class Anime4Up : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     private val streamwishExtractor by lazy { StreamWishExtractor(client, headers) }
     private val vidbomExtractor by lazy { VidBomExtractor(client) }
     private val vidyardExtractor by lazy { VidYardExtractor(client, headers) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
 
     private fun extractVideos(url: String): List<Video> {
         return when {

--- a/src/ar/arabseed/src/eu/kanade/tachiyomi/animeextension/ar/arabseed/ArabSeed.kt
+++ b/src/ar/arabseed/src/eu/kanade/tachiyomi/animeextension/ar/arabseed/ArabSeed.kt
@@ -93,7 +93,7 @@ class ArabSeed : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     private val doodExtractor by lazy { DoodExtractor(client) }
     private val streamwishExtractor by lazy { StreamWishExtractor(client, headers) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
 
     private fun getVideosFromUrl(url: String, quality: String): List<Video> {
         return when {

--- a/src/ar/okanime/src/eu/kanade/tachiyomi/animeextension/ar/okanime/Okanime.kt
+++ b/src/ar/okanime/src/eu/kanade/tachiyomi/animeextension/ar/okanime/Okanime.kt
@@ -155,7 +155,7 @@ class Okanime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     private val doodExtractor by lazy { DoodExtractor(client) }
     private val mp4uploadExtractor by lazy { Mp4uploadExtractor(client) }
     private val okruExtractor by lazy { OkruExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val vidBomExtractor by lazy { VidBomExtractor(client) }
 
     private fun extractVideosFromUrl(url: String, quality: String, selection: Set<String>): List<Video> {

--- a/src/de/animebase/src/eu/kanade/tachiyomi/animeextension/de/animebase/AnimeBase.kt
+++ b/src/de/animebase/src/eu/kanade/tachiyomi/animeextension/de/animebase/AnimeBase.kt
@@ -209,7 +209,7 @@ class AnimeBase : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     }
 
     private val streamWishExtractor by lazy { StreamWishExtractor(client, headers) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val unpackerExtractor by lazy { UnpackerExtractor(client, headers) }
     private val vidguardExtractor by lazy { VidGuardExtractor(client) }
 

--- a/src/de/animeloads/src/eu/kanade/tachiyomi/animeextension/de/animeloads/AnimeLoads.kt
+++ b/src/de/animeloads/src/eu/kanade/tachiyomi/animeextension/de/animeloads/AnimeLoads.kt
@@ -223,7 +223,7 @@ class AnimeLoads : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                                                             val link = client.newCall(GET(decode)).execute().request.url.toString()
                                                             when {
                                                                 hoster.contains("voesx") && hosterSelection?.contains("voe") == true -> {
-                                                                    videoList.addAll(VoeExtractor(client).videosFromUrl(link, "(Deutsch Sub) "))
+                                                                    videoList.addAll(VoeExtractor(client, headers).videosFromUrl(link, "(Deutsch Sub) "))
                                                                 }
 
                                                                 hoster.contains("streamtapecom") && hosterSelection?.contains("stape") == true -> {
@@ -253,7 +253,7 @@ class AnimeLoads : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                                                         } else {
                                                             when {
                                                                 hoster.contains("voesx") && hosterSelection?.contains("voe") == true -> {
-                                                                    videoList.addAll(VoeExtractor(client).videosFromUrl(leaveurl, "(Deutsch Sub) "))
+                                                                    videoList.addAll(VoeExtractor(client, headers).videosFromUrl(leaveurl, "(Deutsch Sub) "))
                                                                 }
 
                                                                 hoster.contains("streamtapecom") && hosterSelection?.contains("stape") == true -> {
@@ -336,7 +336,7 @@ class AnimeLoads : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                                                             val link = client.newCall(GET(decode)).execute().request.url.toString()
                                                             when {
                                                                 hoster.contains("voesx") && hosterSelection?.contains("voe") == true -> {
-                                                                    videoList.addAll(VoeExtractor(client).videosFromUrl(link, "(Deutsch Sub) "))
+                                                                    videoList.addAll(VoeExtractor(client, headers).videosFromUrl(link, "(Deutsch Sub) "))
                                                                 }
 
                                                                 hoster.contains("streamtapecom") && hosterSelection?.contains("stape") == true -> {
@@ -366,7 +366,7 @@ class AnimeLoads : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                                                         } else {
                                                             when {
                                                                 hoster.contains("voesx") && hosterSelection?.contains("voe") == true -> {
-                                                                    videoList.addAll(VoeExtractor(client).videosFromUrl(leaveurl, "(Deutsch Sub) "))
+                                                                    videoList.addAll(VoeExtractor(client, headers).videosFromUrl(leaveurl, "(Deutsch Sub) "))
                                                                 }
 
                                                                 hoster.contains("streamtapecom") && hosterSelection?.contains("stape") == true -> {
@@ -511,7 +511,7 @@ class AnimeLoads : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                                                             val link = client.newCall(GET(decode)).execute().request.url.toString()
                                                             when {
                                                                 hoster.contains("voesx") && hosterSelection?.contains("voe") == true -> {
-                                                                    videoList.addAll(VoeExtractor(client).videosFromUrl(link, "(Deutsch Dub) "))
+                                                                    videoList.addAll(VoeExtractor(client, headers).videosFromUrl(link, "(Deutsch Dub) "))
                                                                 }
 
                                                                 hoster.contains("streamtapecom") && hosterSelection?.contains("stape") == true -> {
@@ -541,7 +541,7 @@ class AnimeLoads : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                                                         } else {
                                                             when {
                                                                 hoster.contains("voesx") && hosterSelection?.contains("voe") == true -> {
-                                                                    videoList.addAll(VoeExtractor(client).videosFromUrl(leaveurl, "(Deutsch Dub) "))
+                                                                    videoList.addAll(VoeExtractor(client, headers).videosFromUrl(leaveurl, "(Deutsch Dub) "))
                                                                 }
 
                                                                 hoster.contains("streamtapecom") && hosterSelection?.contains("stape") == true -> {
@@ -624,7 +624,7 @@ class AnimeLoads : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                                                             val link = client.newCall(GET(decode)).execute().request.url.toString()
                                                             when {
                                                                 hoster.contains("voesx") && hosterSelection?.contains("voe") == true -> {
-                                                                    videoList.addAll(VoeExtractor(client).videosFromUrl(link, "(Deutsch Dub) "))
+                                                                    videoList.addAll(VoeExtractor(client, headers).videosFromUrl(link, "(Deutsch Dub) "))
                                                                 }
 
                                                                 hoster.contains("streamtapecom") && hosterSelection?.contains("stape") == true -> {
@@ -654,7 +654,7 @@ class AnimeLoads : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                                                         } else {
                                                             when {
                                                                 hoster.contains("voesx") && hosterSelection?.contains("voe") == true -> {
-                                                                    videoList.addAll(VoeExtractor(client).videosFromUrl(leaveurl, "(Deutsch Dub) "))
+                                                                    videoList.addAll(VoeExtractor(client, headers).videosFromUrl(leaveurl, "(Deutsch Dub) "))
                                                                 }
 
                                                                 hoster.contains("streamtapecom") && hosterSelection?.contains("stape") == true -> {

--- a/src/de/animetoast/src/eu/kanade/tachiyomi/animeextension/de/animetoast/AnimeToast.kt
+++ b/src/de/animetoast/src/eu/kanade/tachiyomi/animeextension/de/animetoast/AnimeToast.kt
@@ -145,7 +145,7 @@ class AnimeToast : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                                     link.contains("https://voe.sx") && hosterSelection?.contains(
                                         "voe",
                                     ) == true -> {
-                                        videoList.addAll(VoeExtractor(client).videosFromUrl(link))
+                                        videoList.addAll(VoeExtractor(client, headers).videosFromUrl(link))
                                     }
                                 }
                             }
@@ -205,7 +205,7 @@ class AnimeToast : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                         val link = element.select("a").attr("abs:href")
                         when {
                             link.contains("https://voe.sx") && hosterSelection?.contains("voe") == true -> {
-                                videoList.addAll(VoeExtractor(client).videosFromUrl(link))
+                                videoList.addAll(VoeExtractor(client, headers).videosFromUrl(link))
                             }
                         }
                     }

--- a/src/de/aniworld/src/eu/kanade/tachiyomi/animeextension/de/aniworld/AniWorld.kt
+++ b/src/de/aniworld/src/eu/kanade/tachiyomi/animeextension/de/aniworld/AniWorld.kt
@@ -218,7 +218,7 @@ class AniWorld : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                 when {
                     hoster.contains("VOE") && hosterSelection.contains(AWConstants.NAME_VOE) -> {
                         val url = client.newCall(GET(redirectgs)).execute().request.url.toString()
-                        videoList.addAll(VoeExtractor(client).videosFromUrl(url, "($language) "))
+                        videoList.addAll(VoeExtractor(client, headers).videosFromUrl(url, "($language) "))
                     }
 
                     hoster.contains("Doodstream") && hosterSelection.contains(AWConstants.NAME_DOOD) -> {

--- a/src/de/einfach/src/eu/kanade/tachiyomi/animeextension/de/einfach/Einfach.kt
+++ b/src/de/einfach/src/eu/kanade/tachiyomi/animeextension/de/einfach/Einfach.kt
@@ -192,7 +192,7 @@ class Einfach : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     private val streamtapeExtractor by lazy { StreamTapeExtractor(client) }
     private val streamwishExtractor by lazy { StreamWishExtractor(client, headers) }
     private val vidozaExtractor by lazy { VidozaExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
 
     private fun getVideosFromUrl(name: String, url: String): List<Video> {
         return when (name) {

--- a/src/de/filmpalast/src/eu/kanade/tachiyomi/animeextension/de/filmpalast/FilmPalast.kt
+++ b/src/de/filmpalast/src/eu/kanade/tachiyomi/animeextension/de/filmpalast/FilmPalast.kt
@@ -82,7 +82,7 @@ class FilmPalast : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
             }
             when {
                 url.contains("voe") && hosterSelection.contains("voe") ->
-                    VoeExtractor(client).videosFromUrl(url)
+                    VoeExtractor(client, headers).videosFromUrl(url)
 
                 url.contains("upstream") && hosterSelection.contains("up") ->
                     UpstreamExtractor(client).videoFromUrl(url)

--- a/src/de/kinoking/src/eu/kanade/tachiyomi/animeextension/de/kinoking/Kinoking.kt
+++ b/src/de/kinoking/src/eu/kanade/tachiyomi/animeextension/de/kinoking/Kinoking.kt
@@ -82,7 +82,7 @@ class Kinoking : DooPlay(
     }
 
     private val doodExtractor by lazy { DoodExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
 
     private fun getPlayerVideos(link: String, element: Element, hosterSelection: Set<String>): List<Video> {
         return when {

--- a/src/de/kool/src/eu/kanade/tachiyomi/animeextension/de/kool/Kool.kt
+++ b/src/de/kool/src/eu/kanade/tachiyomi/animeextension/de/kool/Kool.kt
@@ -383,7 +383,7 @@ class Kool : ConfigurableAnimeSource, AnimeHttpSource() {
                 item.jsonObject["url"]!!.jsonPrimitive.content.contains("https://voe") ||
                     item.jsonObject["url"]!!.jsonPrimitive.content.contains("scatch176duplicities") && hosterSelection?.contains("voe") == true -> {
                     val videoUrl = item.jsonObject["url"]!!.jsonPrimitive.content
-                    videoList.addAll(VoeExtractor(client).videosFromUrl(videoUrl))
+                    videoList.addAll(VoeExtractor(client, headers).videosFromUrl(videoUrl))
                 }
                 item.jsonObject["url"]!!.jsonPrimitive.content.contains("https://clipboard") && hosterSelection?.contains("clip") == true -> {
                     val videoUrl = item.jsonObject["url"]!!.jsonPrimitive.content

--- a/src/de/movie4k/src/eu/kanade/tachiyomi/animeextension/de/movie4k/Movie4k.kt
+++ b/src/de/movie4k/src/eu/kanade/tachiyomi/animeextension/de/movie4k/Movie4k.kt
@@ -215,7 +215,7 @@ class Movie4k : ConfigurableAnimeSource, AnimeHttpSource() {
                         link.contains("//voe.sx") || link.contains("//launchreliantcleaverriver") ||
                             link.contains("//fraudclatterflyingcar") ||
                             link.contains("//uptodatefinishconferenceroom") || link.contains("//realfinanceblogcenter") && hosterSelection?.contains("voe") == true -> {
-                            videoList.addAll(VoeExtractor(client).videosFromUrl(if (link.contains("https:")) link else "https:$link"))
+                            videoList.addAll(VoeExtractor(client, headers).videosFromUrl(if (link.contains("https:")) link else "https:$link"))
                         }
                     }
                 }
@@ -298,7 +298,7 @@ class Movie4k : ConfigurableAnimeSource, AnimeHttpSource() {
                     link.contains("//voe.sx") || link.contains("//launchreliantcleaverriver") ||
                         link.contains("//fraudclatterflyingcar") ||
                         link.contains("//uptodatefinishconferenceroom") || link.contains("//realfinanceblogcenter") && hosterSelection?.contains("voe") == true -> {
-                        videoList.addAll(VoeExtractor(client).videosFromUrl(if (link.contains("https:")) link else "https:$link"))
+                        videoList.addAll(VoeExtractor(client, headers).videosFromUrl(if (link.contains("https:")) link else "https:$link"))
                     }
                 }
             }

--- a/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
+++ b/src/de/serienstream/src/eu/kanade/tachiyomi/animeextension/de/serienstream/Serienstream.kt
@@ -214,7 +214,7 @@ class Serienstream : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                 when {
                     hoster.contains("VOE") && hosterSelection.contains(SConstants.NAME_VOE) -> {
                         val url = client.newCall(GET(redirectgs)).execute().request.url.toString()
-                        videoList.addAll(VoeExtractor(client).videosFromUrl(url, "($language) "))
+                        videoList.addAll(VoeExtractor(client, headers).videosFromUrl(url, "($language) "))
                     }
 
                     hoster.contains("Doodstream") && hosterSelection.contains(SConstants.NAME_DOOD) -> {

--- a/src/es/animefenix/src/eu/kanade/tachiyomi/animeextension/es/animefenix/Animefenix.kt
+++ b/src/es/animefenix/src/eu/kanade/tachiyomi/animeextension/es/animefenix/Animefenix.kt
@@ -129,7 +129,7 @@ class Animefenix : ConfigurableAnimeSource, AnimeHttpSource() {
 
     /*-------------------------------- Video extractors ------------------------------------*/
     private val universalExtractor by lazy { UniversalExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val okruExtractor by lazy { OkruExtractor(client) }
     private val filemoonExtractor by lazy { FilemoonExtractor(client) }
     private val uqloadExtractor by lazy { UqloadExtractor(client) }

--- a/src/es/animejl/src/eu/kanade/tachiyomi/animeextension/es/animejl/Animejl.kt
+++ b/src/es/animejl/src/eu/kanade/tachiyomi/animeextension/es/animejl/Animejl.kt
@@ -111,7 +111,7 @@ class Animejl : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     private val streamWishExtractor by lazy { StreamWishExtractor(client, headers) }
     private val universalExtractor by lazy { UniversalExtractor(client) }
     private val streamHideVidExtractor by lazy { StreamHideVidExtractor(client, headers) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val uqloadExtractor by lazy { UqloadExtractor(client) }
     private val mp4uploadExtractor by lazy { Mp4uploadExtractor(client) }
 

--- a/src/es/animemovil/src/eu/kanade/tachiyomi/animeextension/es/animemovil/AnimeMovil.kt
+++ b/src/es/animemovil/src/eu/kanade/tachiyomi/animeextension/es/animemovil/AnimeMovil.kt
@@ -232,7 +232,7 @@ class AnimeMovil : ConfigurableAnimeSource, AnimeHttpSource() {
         try {
             return when {
                 embedUrl.contains("voe") -> {
-                    VoeExtractor(client).videosFromUrl(url).also(videoList::addAll)
+                    VoeExtractor(client, headers).videosFromUrl(url).also(videoList::addAll)
                 }
                 embedUrl.contains("filemoon") || embedUrl.contains("moonplayer") -> {
                     FilemoonExtractor(client).videosFromUrl(url, prefix = "Filemoon:").also(videoList::addAll)

--- a/src/es/cine24h/src/eu/kanade/tachiyomi/animeextension/es/cine24h/Cine24h.kt
+++ b/src/es/cine24h/src/eu/kanade/tachiyomi/animeextension/es/cine24h/Cine24h.kt
@@ -149,7 +149,7 @@ open class Cine24h : ConfigurableAnimeSource, AnimeHttpSource() {
     /*--------------------------------Video extractors------------------------------------*/
     private val filemoonExtractor by lazy { FilemoonExtractor(client) }
     private val doodExtractor by lazy { DoodExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val vidGuardExtractor by lazy { VidGuardExtractor(client) }
     private val universalExtractor by lazy { UniversalExtractor(client) }
 

--- a/src/es/cinecalidad/src/eu/kanade/tachiyomi/animeextension/es/cinecalidad/CineCalidad.kt
+++ b/src/es/cinecalidad/src/eu/kanade/tachiyomi/animeextension/es/cinecalidad/CineCalidad.kt
@@ -128,7 +128,7 @@ class CineCalidad : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         val embedUrl = url.lowercase()
         return runCatching {
             when {
-                embedUrl.contains("voe") -> VoeExtractor(client).videosFromUrl(url)
+                embedUrl.contains("voe") -> VoeExtractor(client, headers).videosFromUrl(url)
                 embedUrl.contains("ok.ru") || embedUrl.contains("okru") -> OkruExtractor(client).videosFromUrl(url)
                 embedUrl.contains("filemoon") || embedUrl.contains("moonplayer") -> {
                     val vidHeaders = headers.newBuilder()

--- a/src/es/cuevana/src/eu/kanade/tachiyomi/animeextension/es/cuevana/CuevanaCh.kt
+++ b/src/es/cuevana/src/eu/kanade/tachiyomi/animeextension/es/cuevana/CuevanaCh.kt
@@ -158,7 +158,7 @@ class CuevanaCh(override val name: String, override val baseUrl: String) : Confi
         try {
             return when {
                 embedUrl.contains("voe") -> {
-                    VoeExtractor(client).videosFromUrl(url, prefix).also(videoList::addAll)
+                    VoeExtractor(client, headers).videosFromUrl(url, prefix).also(videoList::addAll)
                     videoList
                 }
                 (embedUrl.contains("amazon") || embedUrl.contains("amz")) && !embedUrl.contains("disable") -> {

--- a/src/es/cuevana/src/eu/kanade/tachiyomi/animeextension/es/cuevana/CuevanaEu.kt
+++ b/src/es/cuevana/src/eu/kanade/tachiyomi/animeextension/es/cuevana/CuevanaEu.kt
@@ -192,7 +192,7 @@ class CuevanaEu(override val name: String, override val baseUrl: String) : Confi
                 videoList
             }
             embedUrl.contains("voe") -> {
-                VoeExtractor(client).videosFromUrl(url, prefix).also(videoList::addAll)
+                VoeExtractor(client, headers).videosFromUrl(url, prefix).also(videoList::addAll)
                 videoList
             }
             embedUrl.contains("streamtape") -> {

--- a/src/es/detodopeliculas/src/eu/kanade/tachiyomi/animeextension/es/detodopeliculas/DeTodoPeliculas.kt
+++ b/src/es/detodopeliculas/src/eu/kanade/tachiyomi/animeextension/es/detodopeliculas/DeTodoPeliculas.kt
@@ -44,7 +44,7 @@ class DeTodoPeliculas : DooPlay(
     private val streamWishExtractor by lazy { StreamWishExtractor(client, headers) }
     private val streamHideVidExtractor by lazy { StreamHideVidExtractor(client, headers) }
     private val vidGuardExtractor by lazy { VidGuardExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
 
 // ============================ Video Links =============================
     override fun videoListParse(response: Response): List<Video> {

--- a/src/es/doramasflix/src/eu/kanade/tachiyomi/animeextension/es/doramasflix/Doramasflix.kt
+++ b/src/es/doramasflix/src/eu/kanade/tachiyomi/animeextension/es/doramasflix/Doramasflix.kt
@@ -481,7 +481,7 @@ class Doramasflix : ConfigurableAnimeSource, AnimeHttpSource() {
     private fun serverVideoResolver(url: String, prefix: String = ""): List<Video> {
         val embedUrl = url.lowercase()
         return when {
-            "voe" in embedUrl -> VoeExtractor(client).videosFromUrl(url, " $prefix")
+            "voe" in embedUrl -> VoeExtractor(client, headers).videosFromUrl(url, " $prefix")
             "ok.ru" in embedUrl || "okru" in embedUrl -> OkruExtractor(client).videosFromUrl(url, prefix = "$prefix ")
             "filemoon" in embedUrl || "moonplayer" in embedUrl -> {
                 val vidHeaders = headers.newBuilder()

--- a/src/es/doramasyt/src/eu/kanade/tachiyomi/animeextension/es/doramasyt/Doramasyt.kt
+++ b/src/es/doramasyt/src/eu/kanade/tachiyomi/animeextension/es/doramasyt/Doramasyt.kt
@@ -178,7 +178,7 @@ class Doramasyt : ConfigurableAnimeSource, AnimeHttpSource() {
 
     override fun getFilterList(): AnimeFilterList = DoramasytFilters.FILTER_LIST
 
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val streamwishExtractor by lazy { StreamWishExtractor(client, headers) }
     private val filemoonExtractor by lazy { FilemoonExtractor(client) }
     private val mixdropExtractor by lazy { MixDropExtractor(client) }

--- a/src/es/ennovelas/src/eu/kanade/tachiyomi/animeextension/es/ennovelas/EnNovelas.kt
+++ b/src/es/ennovelas/src/eu/kanade/tachiyomi/animeextension/es/ennovelas/EnNovelas.kt
@@ -160,7 +160,7 @@ class EnNovelas : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
             }
             if (link.contains("voe")) {
                 try {
-                    VoeExtractor(client).videosFromUrl(link).also(videoList::addAll)
+                    VoeExtractor(client, headers).videosFromUrl(link).also(videoList::addAll)
                 } catch (_: Exception) {}
             }
             if (link.contains("vudeo")) {

--- a/src/es/estrenosdoramas/src/eu/kanade/tachiyomi/animeextension/es/estrenosdoramas/EstrenosDoramas.kt
+++ b/src/es/estrenosdoramas/src/eu/kanade/tachiyomi/animeextension/es/estrenosdoramas/EstrenosDoramas.kt
@@ -131,7 +131,7 @@ class EstrenosDoramas : ConfigurableAnimeSource, AnimeHttpSource() {
     private val okruExtractor by lazy { OkruExtractor(client) }
     private val streamWishExtractor by lazy { StreamWishExtractor(client, headers) }
     private val streamHideVidExtractor by lazy { StreamHideVidExtractor(client, headers) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val yourUploadExtractor by lazy { YourUploadExtractor(client) }
     private val vidGuardExtractor by lazy { VidGuardExtractor(client) }
 

--- a/src/es/flixlatam/src/eu/kanade/tachiyomi/animeextension/es/flixlatam/FlixLatam.kt
+++ b/src/es/flixlatam/src/eu/kanade/tachiyomi/animeextension/es/flixlatam/FlixLatam.kt
@@ -95,7 +95,7 @@ class FlixLatam : DooPlay(
     }
 
     /*-------------------------------- Video extractors ------------------------------------*/
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val okruExtractor by lazy { OkruExtractor(client) }
     private val filemoonExtractor by lazy { FilemoonExtractor(client) }
     private val uqloadExtractor by lazy { UqloadExtractor(client) }

--- a/src/es/gnula/src/eu/kanade/tachiyomi/animeextension/es/gnula/Gnula.kt
+++ b/src/es/gnula/src/eu/kanade/tachiyomi/animeextension/es/gnula/Gnula.kt
@@ -158,7 +158,7 @@ class Gnula : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     private fun serverVideoResolver(url: String, prefix: String = ""): List<Video> {
         val embedUrl = url.lowercase()
         return when {
-            embedUrl.contains("voe") -> VoeExtractor(client).videosFromUrl(url, prefix)
+            embedUrl.contains("voe") -> VoeExtractor(client, headers).videosFromUrl(url, prefix)
             embedUrl.contains("ok.ru") || embedUrl.contains("okru") -> OkruExtractor(client).videosFromUrl(url, prefix)
             embedUrl.contains("filemoon") || embedUrl.contains("moonplayer") -> {
                 val vidHeaders = headers.newBuilder()

--- a/src/es/hackstore/src/eu/kanade/tachiyomi/animeextension/es/hackstore/Hackstore.kt
+++ b/src/es/hackstore/src/eu/kanade/tachiyomi/animeextension/es/hackstore/Hackstore.kt
@@ -192,7 +192,7 @@ class Hackstore : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     /*--------------------------------Video extractors------------------------------------*/
     private val streamTapeExtractor by lazy { StreamTapeExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val filemoonExtractor by lazy { FilemoonExtractor(client) }
     private val streamWishExtractor by lazy { StreamWishExtractor(client, headers) }
     private val doodExtractor by lazy { DoodExtractor(client) }

--- a/src/es/hentaila/src/eu/kanade/tachiyomi/animeextension/es/hentaila/Hentaila.kt
+++ b/src/es/hentaila/src/eu/kanade/tachiyomi/animeextension/es/hentaila/Hentaila.kt
@@ -190,7 +190,7 @@ class Hentaila : ConfigurableAnimeSource, AnimeHttpSource() {
 
     /*--------------------------------Video extractors------------------------------------*/
     private val streamWishExtractor by lazy { StreamWishExtractor(client, headers) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val yourUploadExtractor by lazy { YourUploadExtractor(client) }
     private val mp4uploadExtractor by lazy { Mp4uploadExtractor(client) }
     private val burstCloudExtractor by lazy { BurstCloudExtractor(client) }

--- a/src/es/hentaitk/src/eu/kanade/tachiyomi/animeextension/es/hentaitk/Hentaitk.kt
+++ b/src/es/hentaitk/src/eu/kanade/tachiyomi/animeextension/es/hentaitk/Hentaitk.kt
@@ -132,7 +132,7 @@ class Hentaitk : ConfigurableAnimeSource, AnimeHttpSource() {
     /*--------------------------------Video extractors------------------------------------*/
     private val okruExtractor by lazy { OkruExtractor(client) }
     private val streamWishExtractor by lazy { StreamWishExtractor(client, headers) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val yourUploadExtractor by lazy { YourUploadExtractor(client) }
     private val streamHideVidExtractor by lazy { StreamHideVidExtractor(client, headers) }
     private val doodExtractor by lazy { DoodExtractor(client) }

--- a/src/es/homecine/src/eu/kanade/tachiyomi/animeextension/es/homecine/HomeCine.kt
+++ b/src/es/homecine/src/eu/kanade/tachiyomi/animeextension/es/homecine/HomeCine.kt
@@ -201,7 +201,7 @@ class HomeCine : ConfigurableAnimeSource, AnimeHttpSource() {
                     YourUploadExtractor(client).videoFromUrl(src, headers, prefix = "$prefix ").let { videoList.addAll(it) }
                 }
                 if (src.contains("voe")) {
-                    VoeExtractor(client).videosFromUrl(src, prefix = "$prefix ").also(videoList::addAll)
+                    VoeExtractor(client, headers).videosFromUrl(src, prefix = "$prefix ").also(videoList::addAll)
                 }
                 if (src.contains("wishembed") || src.contains("streamwish") || src.contains("wish")) {
                     StreamWishExtractor(client, headers).videosFromUrl(src) { "$prefix StreamWish:$it" }.also(videoList::addAll)

--- a/src/es/jkanime/src/eu/kanade/tachiyomi/animeextension/es/jkanime/Jkanime.kt
+++ b/src/es/jkanime/src/eu/kanade/tachiyomi/animeextension/es/jkanime/Jkanime.kt
@@ -341,7 +341,7 @@ class Jkanime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
     /*--------------------------------Video extractors------------------------------------*/
     private val okruExtractor by lazy { OkruExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val filemoonExtractor by lazy { FilemoonExtractor(client) }
     private val streamTapeExtractor by lazy { StreamTapeExtractor(client) }
     private val mp4uploadExtractor by lazy { Mp4uploadExtractor(client) }

--- a/src/es/lacartoons/src/eu/kanade/tachiyomi/animeextension/es/lacartoons/Lacartoons.kt
+++ b/src/es/lacartoons/src/eu/kanade/tachiyomi/animeextension/es/lacartoons/Lacartoons.kt
@@ -141,7 +141,7 @@ class Lacartoons : ConfigurableAnimeSource, AnimeHttpSource() {
             }
             embedUrl.contains("vidhide") || embedUrl.contains("streamhide") ||
                 embedUrl.contains("guccihide") || embedUrl.contains("streamvid") -> StreamHideVidExtractor(client, headers).videosFromUrl(url)
-            embedUrl.contains("voe") -> VoeExtractor(client).videosFromUrl(url)
+            embedUrl.contains("voe") -> VoeExtractor(client, headers).videosFromUrl(url)
             embedUrl.contains("yourupload") || embedUrl.contains("upload") -> YourUploadExtractor(client).videoFromUrl(url, headers = headers)
             else -> UniversalExtractor(client).videosFromUrl(url, headers)
         }

--- a/src/es/latanime/src/eu/kanade/tachiyomi/animeextension/es/latanime/Latanime.kt
+++ b/src/es/latanime/src/eu/kanade/tachiyomi/animeextension/es/latanime/Latanime.kt
@@ -278,7 +278,7 @@ class Latanime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     /*--------------------------------Video extractors------------------------------------*/
     private val okruExtractor by lazy { OkruExtractor(client) }
     private val mp4uploadExtractor by lazy { Mp4uploadExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val uqloadExtractor by lazy { UqloadExtractor(client) }
     private val doodExtractor by lazy { DoodExtractor(client) }
     private val yourUploadExtractor by lazy { YourUploadExtractor(client) }

--- a/src/es/metroseries/src/eu/kanade/tachiyomi/animeextension/es/metroseries/MetroSeries.kt
+++ b/src/es/metroseries/src/eu/kanade/tachiyomi/animeextension/es/metroseries/MetroSeries.kt
@@ -200,7 +200,7 @@ class MetroSeries : ConfigurableAnimeSource, AnimeHttpSource() {
                     YourUploadExtractor(client).videoFromUrl(src, headers, prefix = "$prefix ").let { videoList.addAll(it) }
                 }
                 if (src.contains("voe")) {
-                    VoeExtractor(client).videosFromUrl(src, prefix = "$prefix ").also(videoList::addAll)
+                    VoeExtractor(client, headers).videosFromUrl(src, prefix = "$prefix ").also(videoList::addAll)
                 }
                 if (src.contains("wishembed") || src.contains("streamwish") || src.contains("wish")) {
                     StreamWishExtractor(client, headers).videosFromUrl(src) { "$prefix StreamWish:$it" }.also(videoList::addAll)

--- a/src/es/mhdflix/src/eu/kanade/tachiyomi/animeextension/es/mhdflix/MhdFlix.kt
+++ b/src/es/mhdflix/src/eu/kanade/tachiyomi/animeextension/es/mhdflix/MhdFlix.kt
@@ -247,7 +247,7 @@ open class MhdFlix : AnimeHttpSource(), ConfigurableAnimeSource {
     }
 
     private val vidHideExtractor by lazy { VidHideExtractor(client, headers) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val uqloadExtractor by lazy { UqloadExtractor(client) }
     private val streamTapeExtractor by lazy { StreamTapeExtractor(client) }
     private val doodExtractor by lazy { DoodExtractor(client) }

--- a/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/MonosChinos.kt
+++ b/src/es/monoschinos/src/eu/kanade/tachiyomi/animeextension/es/monoschinos/MonosChinos.kt
@@ -178,7 +178,7 @@ class MonosChinos : ConfigurableAnimeSource, AnimeHttpSource() {
 
     override fun getFilterList(): AnimeFilterList = MonosChinosFilters.FILTER_LIST
 
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val streamwishExtractor by lazy { StreamWishExtractor(client, headers) }
     private val filemoonExtractor by lazy { FilemoonExtractor(client) }
     private val mixdropExtractor by lazy { MixDropExtractor(client) }

--- a/src/es/mundodonghua/src/eu/kanade/tachiyomi/animeextension/es/mundodonghua/MundoDonghua.kt
+++ b/src/es/mundodonghua/src/eu/kanade/tachiyomi/animeextension/es/mundodonghua/MundoDonghua.kt
@@ -103,7 +103,7 @@ class MundoDonghua : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                     if (unpack.contains("amagi_tab")) {
                         fetchUrls(unpack).map { url ->
                             try {
-                                VoeExtractor(client).videosFromUrl(url).also(videoList::addAll)
+                                VoeExtractor(client, headers).videosFromUrl(url).also(videoList::addAll)
                             } catch (_: Exception) {}
                         }
                     }

--- a/src/es/otakuverso/src/eu/kanade/tachiyomi/animeextension/es/otakuverso/Otakuverso.kt
+++ b/src/es/otakuverso/src/eu/kanade/tachiyomi/animeextension/es/otakuverso/Otakuverso.kt
@@ -222,7 +222,7 @@ class Otakuverso : ConfigurableAnimeSource, AnimeHttpSource() {
 
     /*-------------------------------- Video extractors ------------------------------------*/
     private val universalExtractor by lazy { UniversalExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val okruExtractor by lazy { OkruExtractor(client) }
     private val filemoonExtractor by lazy { FilemoonExtractor(client) }
     private val uqloadExtractor by lazy { UqloadExtractor(client) }

--- a/src/es/pelisforte/src/eu/kanade/tachiyomi/animeextension/es/pelisforte/PelisForte.kt
+++ b/src/es/pelisforte/src/eu/kanade/tachiyomi/animeextension/es/pelisforte/PelisForte.kt
@@ -171,7 +171,7 @@ open class PelisForte : ConfigurableAnimeSource, AnimeHttpSource() {
     }
 
     /*--------------------------------Video extractors------------------------------------*/
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val okruExtractor by lazy { OkruExtractor(client) }
     private val filemoonExtractor by lazy { FilemoonExtractor(client) }
     private val uqloadExtractor by lazy { UqloadExtractor(client) }

--- a/src/es/pelisplushd/src/eu/kanade/tachiyomi/animeextension/es/pelisplushd/Pelisplushd.kt
+++ b/src/es/pelisplushd/src/eu/kanade/tachiyomi/animeextension/es/pelisplushd/Pelisplushd.kt
@@ -165,7 +165,7 @@ open class Pelisplushd(override val name: String, override val baseUrl: String) 
     }
 
     /*--------------------------------Video extractors------------------------------------*/
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val okruExtractor by lazy { OkruExtractor(client) }
     private val filemoonExtractor by lazy { FilemoonExtractor(client) }
     private val uqloadExtractor by lazy { UqloadExtractor(client) }

--- a/src/es/serieskao/src/eu/kanade/tachiyomi/animeextension/es/serieskao/Serieskao.kt
+++ b/src/es/serieskao/src/eu/kanade/tachiyomi/animeextension/es/serieskao/Serieskao.kt
@@ -169,7 +169,7 @@ open class Serieskao : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     }
 
     /*--------------------------------Video extractors------------------------------------*/
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val okruExtractor by lazy { OkruExtractor(client) }
     private val filemoonExtractor by lazy { FilemoonExtractor(client) }
     private val uqloadExtractor by lazy { UqloadExtractor(client) }

--- a/src/es/sololatino/src/eu/kanade/tachiyomi/animeextension/es/sololatino/SoloLatino.kt
+++ b/src/es/sololatino/src/eu/kanade/tachiyomi/animeextension/es/sololatino/SoloLatino.kt
@@ -246,7 +246,7 @@ class SoloLatino : DooPlay(
     private val vidGuardExtractor by lazy { VidGuardExtractor(client) }
     private val doodExtractor by lazy { DoodExtractor(client) }
     private val streamHideVidExtractor by lazy { StreamHideVidExtractor(client, headers) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val filemoonExtractor by lazy { FilemoonExtractor(client) }
 
     private fun extractVideos(url: String, lang: String): List<Video> {

--- a/src/es/tioanimeh/src/eu/kanade/tachiyomi/animeextension/es/tioanimeh/TioanimeH.kt
+++ b/src/es/tioanimeh/src/eu/kanade/tachiyomi/animeextension/es/tioanimeh/TioanimeH.kt
@@ -85,7 +85,7 @@ open class TioanimeH(override val name: String, override val baseUrl: String) : 
     override fun episodeFromElement(element: Element) = throw UnsupportedOperationException()
 
     /*--------------------------------Video extractors------------------------------------*/
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val vidGuardExtractor by lazy { VidGuardExtractor(client) }
     private val okruExtractor by lazy { OkruExtractor(client) }
     private val yourUploadExtractor by lazy { YourUploadExtractor(client) }

--- a/src/es/tiodonghua/src/eu/kanade/tachiyomi/animeextension/es/tiodonghua/Tiodonghua.kt
+++ b/src/es/tiodonghua/src/eu/kanade/tachiyomi/animeextension/es/tiodonghua/Tiodonghua.kt
@@ -15,7 +15,7 @@ class Tiodonghua : AnimeStream(
 
     // ============================ Video Links =============================
     private val okruExtractor by lazy { OkruExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val youruploadExtractor by lazy { YourUploadExtractor(client) }
     private val mixdropExtractor by lazy { MixDropExtractor(client) }
 

--- a/src/es/veranimes/src/eu/kanade/tachiyomi/animeextension/es/veranimes/VerAnimes.kt
+++ b/src/es/veranimes/src/eu/kanade/tachiyomi/animeextension/es/veranimes/VerAnimes.kt
@@ -158,7 +158,7 @@ class VerAnimes : ConfigurableAnimeSource, AnimeHttpSource() {
     private val okruExtractor by lazy { OkruExtractor(client) }
     private val streamWishExtractor by lazy { StreamWishExtractor(client, headers) }
     private val streamHideVidExtractor by lazy { StreamHideVidExtractor(client, headers) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val yourUploadExtractor by lazy { YourUploadExtractor(client) }
     private val vidGuardExtractor by lazy { VidGuardExtractor(client) }
     private val universalExtractor by lazy { UniversalExtractor(client) }

--- a/src/es/verseriesonline/src/eu/kanade/tachiyomi/animeextension/es/verseriesonline/VerSeriesOnline.kt
+++ b/src/es/verseriesonline/src/eu/kanade/tachiyomi/animeextension/es/verseriesonline/VerSeriesOnline.kt
@@ -195,7 +195,7 @@ class VerSeriesOnline : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     private val doodExtractor by lazy { DoodExtractor(client) }
     private val streamwishExtractor by lazy { StreamWishExtractor(client, headers) }
     private val streamtapeExtractor by lazy { StreamTapeExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val uqloadExtractor by lazy { UqloadExtractor(client) }
     private val vudeoExtractor by lazy { VudeoExtractor(client) }
 

--- a/src/es/zonaleros/src/eu/kanade/tachiyomi/animeextension/es/zonaleros/Zonaleros.kt
+++ b/src/es/zonaleros/src/eu/kanade/tachiyomi/animeextension/es/zonaleros/Zonaleros.kt
@@ -198,7 +198,7 @@ class Zonaleros : ConfigurableAnimeSource, AnimeHttpSource() {
 
     override fun getFilterList(): AnimeFilterList = ZonalerosFilters.FILTER_LIST
 
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val streamwishExtractor by lazy { StreamWishExtractor(client, headers) }
     private val filemoonExtractor by lazy { FilemoonExtractor(client) }
     private val mixdropExtractor by lazy { MixDropExtractor(client) }

--- a/src/fr/anisama/src/eu/kanade/tachiyomi/animeextension/fr/anisama/AniSama.kt
+++ b/src/fr/anisama/src/eu/kanade/tachiyomi/animeextension/fr/anisama/AniSama.kt
@@ -176,7 +176,7 @@ class AniSama : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
     private val filemoonExtractor by lazy { FilemoonExtractor(client) }
     private val sibnetExtractor by lazy { SibnetExtractor(client) }
     private val sendvidExtractor by lazy { SendvidExtractor(client, headers) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val vidCdnExtractor by lazy { VidCdnExtractor(client) }
     private val doodExtractor by lazy { DoodExtractor(client) }
     private val streamHideVidExtractor by lazy { StreamHideVidExtractor(client, headers) }

--- a/src/fr/empirestreaming/src/eu/kanade/tachiyomi/animeextension/fr/empirestreaming/EmpireStreaming.kt
+++ b/src/fr/empirestreaming/src/eu/kanade/tachiyomi/animeextension/fr/empirestreaming/EmpireStreaming.kt
@@ -164,7 +164,7 @@ class EmpireStreaming : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
 
         return when (hoster) {
             "doodstream" -> DoodExtractor(client).videosFromUrl(url)
-            "voe" -> VoeExtractor(client).videosFromUrl(url)
+            "voe" -> VoeExtractor(client, headers).videosFromUrl(url)
             "Eplayer" -> EplayerExtractor(client).videosFromUrl(url)
             else -> null
         } ?: emptyList()

--- a/src/fr/frenchanime/src/eu/kanade/tachiyomi/animeextension/fr/frenchanime/FrenchAnime.kt
+++ b/src/fr/frenchanime/src/eu/kanade/tachiyomi/animeextension/fr/frenchanime/FrenchAnime.kt
@@ -99,7 +99,7 @@ class FrenchAnime : DataLifeEngine(
     private val okruExtractor by lazy { OkruExtractor(client) }
     private val streamHubExtractor by lazy { StreamHubExtractor(client) }
     private val vidmolyExtractor by lazy { VidMolyExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
 
     override suspend fun getVideoList(episode: SEpisode): List<Video> {
         val list = episode.url.split(",").filter { it.isNotBlank() }.parallelCatchingFlatMap {

--- a/src/fr/otakufr/src/eu/kanade/tachiyomi/animeextension/fr/otakufr/OtakuFR.kt
+++ b/src/fr/otakufr/src/eu/kanade/tachiyomi/animeextension/fr/otakufr/OtakuFR.kt
@@ -142,7 +142,7 @@ class OtakuFR : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     private val upstreamExtractor by lazy { UpstreamExtractor(client) }
     private val okruExtractor by lazy { OkruExtractor(client) }
     private val doodExtractor by lazy { DoodExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val sibnetExtractor by lazy { SibnetExtractor(client) }
 
     override fun videoListParse(response: Response): List<Video> {

--- a/src/fr/vostfree/src/eu/kanade/tachiyomi/animeextension/fr/vostfree/Vostfree.kt
+++ b/src/fr/vostfree/src/eu/kanade/tachiyomi/animeextension/fr/vostfree/Vostfree.kt
@@ -140,7 +140,7 @@ class Vostfree : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     private val okruExtractor by lazy { OkruExtractor(client) }
     private val sibnetExtractor by lazy { SibnetExtractor(client) }
     private val uqloadExtractor by lazy { UqloadExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val vudeoExtractor by lazy { VudeoExtractor(client) }
 
     override fun videoListParse(response: Response) = throw UnsupportedOperationException()

--- a/src/fr/wiflix/src/eu/kanade/tachiyomi/animeextension/fr/wiflix/Wiflix.kt
+++ b/src/fr/wiflix/src/eu/kanade/tachiyomi/animeextension/fr/wiflix/Wiflix.kt
@@ -86,7 +86,7 @@ class Wiflix : DataLifeEngine(
                     contains("streamvid.net") -> StreamHideVidExtractor(client, headers).videosFromUrl(this)
                     contains("upstream.to") -> UpstreamExtractor(client).videosFromUrl(this)
                     contains("streamdav.com") -> StreamDavExtractor(client).videosFromUrl(this)
-                    contains("voe.sx") -> VoeExtractor(client).videosFromUrl(this)
+                    contains("voe.sx") -> VoeExtractor(client, headers).videosFromUrl(this)
                     else -> emptyList()
                 }
             }

--- a/src/it/toonitalia/src/eu/kanade/tachiyomi/animeextension/it/toonitalia/Toonitalia.kt
+++ b/src/it/toonitalia/src/eu/kanade/tachiyomi/animeextension/it/toonitalia/Toonitalia.kt
@@ -184,7 +184,7 @@ class Toonitalia : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
         }
     }
 
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val streamZExtractor by lazy { StreamZExtractor(client) }
     private val streamTapeExtractor by lazy { StreamTapeExtractor(client) }
     private val maxStreamExtractor by lazy { MaxStreamExtractor(client, headers) }

--- a/src/tr/animeler/src/eu/kanade/tachiyomi/animeextension/tr/animeler/Animeler.kt
+++ b/src/tr/animeler/src/eu/kanade/tachiyomi/animeextension/tr/animeler/Animeler.kt
@@ -223,7 +223,7 @@ class Animeler : AnimeHttpSource(), ConfigurableAnimeSource {
     private val streamlareExtractor by lazy { StreamlareExtractor(client) }
     private val streamtapeExtractor by lazy { StreamTapeExtractor(client) }
     private val uqloadExtractor by lazy { UqloadExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val vudeoExtractor by lazy { VudeoExtractor(client) }
 
     override fun videoListParse(response: Response): List<Video> {

--- a/src/tr/anizm/src/eu/kanade/tachiyomi/animeextension/tr/anizm/Anizm.kt
+++ b/src/tr/anizm/src/eu/kanade/tachiyomi/animeextension/tr/anizm/Anizm.kt
@@ -241,7 +241,7 @@ class Anizm : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
     private val sibnetExtractor by lazy { SibnetExtractor(client) }
     private val streamtapeExtractor by lazy { StreamTapeExtractor(client) }
     private val uqloadExtractor by lazy { UqloadExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val yourUploadExtractor by lazy { YourUploadExtractor(client) }
 
     private fun getVideosFromUrl(firstUrl: String): List<Video> {

--- a/src/tr/tranimeizle/src/eu/kanade/tachiyomi/animeextension/tr/tranimeizle/TRAnimeIzle.kt
+++ b/src/tr/tranimeizle/src/eu/kanade/tachiyomi/animeextension/tr/tranimeizle/TRAnimeIzle.kt
@@ -221,7 +221,7 @@ class TRAnimeIzle : ParsedAnimeHttpSource(), ConfigurableAnimeSource {
     private val sendvidExtractor by lazy { SendvidExtractor(client, headers) }
     private val sibnetExtractor by lazy { SibnetExtractor(client) }
     private val streamlareExtractor by lazy { StreamlareExtractor(client) }
-    private val voeExtractor by lazy { VoeExtractor(client) }
+    private val voeExtractor by lazy { VoeExtractor(client, headers) }
     private val vudeoExtractor by lazy { VudeoExtractor(client) }
     private val yourUploadExtractor by lazy { YourUploadExtractor(client) }
 

--- a/src/tr/turkanime/src/eu/kanade/tachiyomi/animeextension/tr/turkanime/TurkAnime.kt
+++ b/src/tr/turkanime/src/eu/kanade/tachiyomi/animeextension/tr/turkanime/TurkAnime.kt
@@ -362,7 +362,7 @@ class TurkAnime : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
                     VkExtractor(client, headers).videosFromUrl(vkUrl, prefix = "$subber: ")
                 }
                 "VOE" -> {
-                    VoeExtractor(client).videosFromUrl(hosterLink, "($subber) ")
+                    VoeExtractor(client, headers).videosFromUrl(hosterLink, "($subber) ")
                 }
                 "VTUBE" -> {
                     VTubeExtractor(client, headers).videosFromUrl(hosterLink, baseUrl, prefix = "$subber: ")


### PR DESCRIPTION
Update VoeExtractor instances across multiple extensions to include headers, ensuring proper functionality and compatibility.

## Summary by Sourcery

Update VoeExtractor to support and apply request headers, and propagate this change across all anime extensions.

Enhancements:
- Modify VoeExtractor constructor to accept OkHttp headers and include them in its GET requests and PlaylistUtils.
- Update all VoeExtractor instantiations in extensions to pass the appropriate headers.
- Fix SupJav extension’s protector URL constant.