### PR TITLE
JellyFin/Stremio: Fix minor bugs and update version codes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,9 @@
   "schedule": ["on sunday"],
   "includePaths": [
     "buildSrc/gradle/**",
+    "buildSrc/*.gradle.kts",
     "gradle/**",
+    "*.gradle.kts",
     ".github/**"
   ],
   "ignoreDeps": [

--- a/core/src/main/kotlin/extensions/utils/Preferences.kt
+++ b/core/src/main/kotlin/extensions/utils/Preferences.kt
@@ -80,7 +80,8 @@ class LazyMutable<T>(
  *
  * @param preferences Shared preferences
  * @param key Key for preference
- * @param default Default value for preference, can be `null` for `String?` or `Set<String>?`. Should be explicitly casted such as `null as String?`.
+ * @param default Default value for preference, can be `null` for `String?` or `Set<String>?`.
+ * Should be explicitly casted such as `null as String?`.
  */
 class PreferenceDelegate<T>(
     val preferences: SharedPreferences,
@@ -89,7 +90,11 @@ class PreferenceDelegate<T>(
 ) : ReadWriteProperty<Any?, T> {
     @Suppress("UNCHECKED_CAST")
     override fun getValue(thisRef: Any?, property: KProperty<*>): T {
-        return synchronized(this) { try {
+        /*
+         * The synchronized(this) is not necessary here and may actually cause performance issues.
+         * The getValue method only performs read operations on SharedPreferences, which are already thread-safe in Android.
+         */
+        return /* KMK --> synchronized(this) { KMK <-- */ try {
             when (default) {
                 is String -> preferences.getString(key, default) as T
                 is Int -> preferences.getInt(key, default) as T
@@ -99,8 +104,8 @@ class PreferenceDelegate<T>(
                 is Set<*> -> preferences.getStringSet(key, default as Set<String>) as T
                 null -> preferences.all[key] as T
                 else -> throw IllegalArgumentException("Unsupported type: ${default.javaClass}")
-            } } catch (e: ClassCastException) { default }
-        }
+            }
+        } catch (e: ClassCastException) { default }
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -129,7 +134,8 @@ class PreferenceDelegate<T>(
  * which will cause the preferences to be created with the wrong source id.
  *
  * @param key Key for preference
- * @param default Default value for preference, can be `null` for `String?` or `Set<String>?`. Should be explicitly casted such as `null as String?`.
+ * @param default Default value for preference, can be `null` for `String?` or `Set<String>?`.
+ * Should be explicitly casted such as `null as String?`.
  */
 fun <T> SharedPreferences.delegate(key: String, default: T) =
     PreferenceDelegate(this, key, default)
@@ -149,7 +155,8 @@ private const val RESTART_MESSAGE = "Restart the app to apply the new setting."
  * @param validate Validate preference value before applying
  * @param validationMessage Validation message if text isn't valid, based on text value
  * @param restartRequired Show restart required toast on preference change
- * @param onChange Run block on changed listener for validation, must return *true/false* to determine if the preference change should be accepted
+ * @param onChange Run block on changed listener for validation, must return *true/false*
+ * to determine if the preference change should be accepted
  * @param onComplete Run block on completion with text value as parameter
  */
 fun PreferenceScreen.getEditTextPreference(
@@ -232,7 +239,8 @@ fun PreferenceScreen.getEditTextPreference(
  * @param validate Validate preference value before applying
  * @param validationMessage Validation message if text isn't valid, based on text value
  * @param restartRequired Show restart required toast on preference change
- * @param onChange Run block on changed listener for validation, must return *true/false* to determine if the preference change should be accepted
+ * @param onChange Run block on changed listener for validation, must return *true/false*
+ * to determine if the preference change should be accepted
  * @param onComplete Run block on completion with text value as parameter
  */
 fun PreferenceScreen.addEditTextPreference(
@@ -277,7 +285,8 @@ fun PreferenceScreen.addEditTextPreference(
  * @param entries Preference entries
  * @param entryValues Preference entry values
  * @param restartRequired Show restart required toast on preference change
- * @param onChange Run block on changed listener for validation, must return *true/false* to determine if the preference change should be accepted
+ * @param onChange Run block on changed listener for validation, must return *true/false*
+ * to determine if the preference change should be accepted
  * @param onComplete Run block on completion with text value as parameter
  */
 fun PreferenceScreen.getListPreference(
@@ -325,7 +334,8 @@ fun PreferenceScreen.getListPreference(
  * @param entries Preference entries
  * @param entryValues Preference entry values
  * @param restartRequired Show restart required toast on preference change
- * @param onChange Run block on changed listener for validation, must return *true/false* to determine if the preference change should be accepted
+ * @param onChange Run block on changed listener for validation, must return *true/false*
+ * to determine if the preference change should be accepted
  * @param onComplete Run block on completion with text value as parameter
  */
 fun PreferenceScreen.addListPreference(
@@ -364,7 +374,8 @@ fun PreferenceScreen.addListPreference(
  * @param entries Preference entries
  * @param entryValues Preference entry values
  * @param restartRequired Show restart required toast on preference change
- * @param onChange Run block on changed listener for validation, must return *true/false* to determine if the preference change should be accepted
+ * @param onChange Run block on changed listener for validation, must return *true/false*
+ * to determine if the preference change should be accepted
  * @param onComplete Run block on completion with text value as parameter
  */
 fun PreferenceScreen.getSetPreference(
@@ -413,7 +424,8 @@ fun PreferenceScreen.getSetPreference(
  * @param entries Preference entries
  * @param entryValues Preference entry values
  * @param restartRequired Show restart required toast on preference change
- * @param onChange Run block on changed listener for validation, must return *true/false* to determine if the preference change should be accepted
+ * @param onChange Run block on changed listener for validation, must return *true/false*
+ * to determine if the preference change should be accepted
  * @param onComplete Run block on completion with text value as parameter
  */
 fun PreferenceScreen.addSetPreference(
@@ -450,7 +462,8 @@ fun PreferenceScreen.addSetPreference(
  * @param title Preference title
  * @param summary Preference summary
  * @param restartRequired Show restart required toast on preference change
- * @param onChange Run block on changed listener for validation, must return *true/false* to determine if the preference change should be accepted
+ * @param onChange Run block on changed listener for validation, must return *true/false*
+ * to determine if the preference change should be accepted
  * @param onComplete Run block on completion with text value as parameter
  */
 fun PreferenceScreen.getSwitchPreference(
@@ -492,7 +505,8 @@ fun PreferenceScreen.getSwitchPreference(
  * @param title Preference title
  * @param summary Preference summary
  * @param restartRequired Show restart required toast on preference change
- * @param onChange Run block on changed listener for validation, must return *true/false* to determine if the preference change should be accepted
+ * @param onChange Run block on changed listener for validation, must return *true/false*
+ * to determine if the preference change should be accepted
  * @param onComplete Run block on completion with text value as parameter
  */
 fun PreferenceScreen.addSwitchPreference(

--- a/src/all/jellyfin/build.gradle
+++ b/src/all/jellyfin/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Jellyfin'
     extClass = '.JellyfinFactory'
-    extVersionCode = 28
+    extVersionCode = 29
     extNames = ["Jellyfin (1)", "Jellyfin (2)", "Jellyfin (3)"]
 }
 

--- a/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
+++ b/src/all/jellyfin/src/eu/kanade/tachiyomi/animeextension/all/jellyfin/Jellyfin.kt
@@ -658,57 +658,27 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
         get() = getString(PREF_CUSTOM_LABEL_KEY, PREF_CUSTOM_LABEL_DEFAULT)!!
 
     private var SharedPreferences.libraryList by preferences.delegate(LIBRARY_LIST_KEY, "[]")
-
-    private val userIdDelegate = preferences.delegate(USERID_KEY, "")
-    private var SharedPreferences.userId by userIdDelegate
-
-    private val apiKeyDelegate = preferences.delegate(APIKEY_KEY, "")
-    private var SharedPreferences.apiKey by apiKeyDelegate
-
-    private val hostUrlDelegate = preferences.delegate(HOSTURL_KEY, HOSTURL_DEFAULT)
-    private val SharedPreferences.hostUrl by hostUrlDelegate
-
-    private val usernameDelegate = preferences.delegate(USERNAME_KEY, USERNAME_DEFAULT)
-    private val SharedPreferences.username by usernameDelegate
-
-    private val passwordDelegate = preferences.delegate(PASSWORD_KEY, PASSWORD_DEFAULT)
-    private val SharedPreferences.password by passwordDelegate
-
-    private val selectedLibraryDelegate = preferences.delegate(MEDIA_LIBRARY_KEY, MEDIA_LIBRARY_DEFAULT)
-    private var SharedPreferences.selectedLibrary by selectedLibraryDelegate
-
-    private val episodeTemplateDelegate = preferences.delegate(
+    private var SharedPreferences.userId by preferences.delegate(USERID_KEY, "")
+    private var SharedPreferences.apiKey by preferences.delegate(APIKEY_KEY, "")
+    private val SharedPreferences.hostUrl by preferences.delegate(HOSTURL_KEY, HOSTURL_DEFAULT)
+    private val SharedPreferences.username by preferences.delegate(USERNAME_KEY, USERNAME_DEFAULT)
+    private val SharedPreferences.password by preferences.delegate(PASSWORD_KEY, PASSWORD_DEFAULT)
+    private var SharedPreferences.selectedLibrary by preferences.delegate(MEDIA_LIBRARY_KEY, MEDIA_LIBRARY_DEFAULT)
+    private val SharedPreferences.episodeTemplate by preferences.delegate(
         PREF_EPISODE_NAME_TEMPLATE_KEY,
         PREF_EPISODE_NAME_TEMPLATE_DEFAULT,
     )
-    private val SharedPreferences.episodeTemplate by episodeTemplateDelegate
-
-    private val epDetailsDelegate = preferences.delegate(PREF_EP_DETAILS_KEY, PREF_EP_DETAILS_DEFAULT)
-    private val SharedPreferences.epDetails by epDetailsDelegate
-
-    private val qualityDelegate = preferences.delegate(PREF_QUALITY_KEY, PREF_QUALITY_DEFAULT)
-    private val SharedPreferences.quality by qualityDelegate
-
-    private val videoCodecDelegate = preferences.delegate(PREF_VIDEO_CODEC_KEY, PREF_VIDEO_CODEC_DEFAULT)
-    private val SharedPreferences.videoCodec by videoCodecDelegate
-
-    private val audioLangDelegate = preferences.delegate(PREF_AUDIO_KEY, PREF_AUDIO_DEFAULT)
-    private val SharedPreferences.audioLang by audioLangDelegate
-
-    private val subLangDelegate = preferences.delegate(PREF_SUB_KEY, PREF_SUB_DEFAULT)
-    private val SharedPreferences.subLang by subLangDelegate
-
-    private val burnSubDelegate = preferences.delegate(PREF_BURN_SUB_KEY, PREF_BURN_SUB_DEFAULT)
-    private val SharedPreferences.burnSub by burnSubDelegate
-
-    private val seriesDataDelegate = preferences.delegate(PREF_INFO_TYPE, PREF_INFO_DEFAULT)
-    private val SharedPreferences.seriesData by seriesDataDelegate
-
-    private val splitCollectionDelegate = preferences.delegate(
+    private val SharedPreferences.epDetails by preferences.delegate(PREF_EP_DETAILS_KEY, PREF_EP_DETAILS_DEFAULT)
+    private val SharedPreferences.quality by preferences.delegate(PREF_QUALITY_KEY, PREF_QUALITY_DEFAULT)
+    private val SharedPreferences.videoCodec by preferences.delegate(PREF_VIDEO_CODEC_KEY, PREF_VIDEO_CODEC_DEFAULT)
+    private val SharedPreferences.audioLang by preferences.delegate(PREF_AUDIO_KEY, PREF_AUDIO_DEFAULT)
+    private val SharedPreferences.subLang by preferences.delegate(PREF_SUB_KEY, PREF_SUB_DEFAULT)
+    private val SharedPreferences.burnSub by preferences.delegate(PREF_BURN_SUB_KEY, PREF_BURN_SUB_DEFAULT)
+    private val SharedPreferences.seriesData by preferences.delegate(PREF_INFO_TYPE, PREF_INFO_DEFAULT)
+    private val SharedPreferences.splitCollections by preferences.delegate(
         PREF_SPLIT_COLLECTIONS_KEY,
         PREF_SPLIT_COLLECTIONS_DEFAULT,
     )
-    private val SharedPreferences.splitCollections by splitCollectionDelegate
 
     private fun clearCredentials() {
         preferences.libraryList = "[]"
@@ -736,7 +706,6 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
             entries = libraryList.map { it.name },
             entryValues = libraryList.map { it.id },
             enabled = preferences.apiKey.isNotBlank(),
-            lazyDelegate = selectedLibraryDelegate,
         )
 
         fun onCompleteLogin(result: Boolean) {
@@ -837,7 +806,6 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
             validationMessage = { "The URL is invalid, malformed, or ends with a slash" },
         ) {
             baseUrl = it
-            hostUrlDelegate.updateValue(it)
 
             if (it.isBlank()) {
                 onCompleteLogin(false)
@@ -856,7 +824,6 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
             summary = userNameSummary(preferences.username),
             getSummary = userNameSummary,
         ) {
-            usernameDelegate.updateValue(it)
             if (it.isBlank()) {
                 onCompleteLogin(false)
             } else {
@@ -877,7 +844,6 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
             getSummary = passwordSummary,
             inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD,
         ) {
-            passwordDelegate.updateValue(it)
             if (it.isBlank()) {
                 onCompleteLogin(false)
             } else {
@@ -923,7 +889,6 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
                 }
             },
             validationMessage = { "Invalid episode title format" },
-            lazyDelegate = episodeTemplateDelegate,
         )
 
         screen.addSetPreference(
@@ -933,7 +898,6 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
             summary = "Show additional details about an episode in the scanlator field",
             entries = PREF_EP_DETAILS,
             entryValues = PREF_EP_DETAILS,
-            lazyDelegate = epDetailsDelegate,
         )
 
         screen.addListPreference(
@@ -943,7 +907,6 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
             summary = "Preferred quality. 'Source' means no transcoding.",
             entries = listOf("Source") + Constants.QUALITIES_LIST.reversed().map { it.description },
             entryValues = listOf("Source") + Constants.QUALITIES_LIST.reversed().map { it.videoBitrate.toString() },
-            lazyDelegate = qualityDelegate,
         )
 
         screen.addEditTextPreference(
@@ -951,7 +914,6 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
             default = PREF_VIDEO_CODEC_DEFAULT,
             title = "Transcoding video codec",
             summary = "Video codec when transcoding. Does not affect 'Source' quality.",
-            lazyDelegate = videoCodecDelegate,
         )
 
         screen.addEditTextPreference(
@@ -968,7 +930,6 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
                     "'$it' is not a three letter code"
                 }
             },
-            lazyDelegate = audioLangDelegate,
         )
 
         screen.addEditTextPreference(
@@ -985,7 +946,6 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
                     "'$it' is not a three letter code"
                 }
             },
-            lazyDelegate = subLangDelegate,
         )
 
         screen.addSwitchPreference(
@@ -993,7 +953,6 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
             default = PREF_BURN_SUB_DEFAULT,
             title = "Burn in subtitles",
             summary = "Burn in subtitles when transcoding. Does not affect 'Source' quality.",
-            lazyDelegate = burnSubDelegate,
         )
 
         screen.addSwitchPreference(
@@ -1001,7 +960,6 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
             default = PREF_INFO_DEFAULT,
             title = "Retrieve metadata from series",
             summary = "Enable this to retrieve metadata from series instead of season when applicable.",
-            lazyDelegate = seriesDataDelegate,
         )
 
         screen.addSwitchPreference(
@@ -1009,7 +967,6 @@ class Jellyfin(private val suffix: String) : Source(), UnmeteredSource {
             default = PREF_SPLIT_COLLECTIONS_DEFAULT,
             title = "Split collections",
             summary = "Split each item in a collection into its own entry",
-            lazyDelegate = splitCollectionDelegate,
         )
     }
 }

--- a/src/all/stremio/build.gradle
+++ b/src/all/stremio/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Stremio'
     extClass = '.Stremio'
-    extVersionCode = 6
+    extVersionCode = 7
     extNames = ["Stremio"]
 }
 

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/Stremio.kt
@@ -428,7 +428,7 @@ class Stremio : Source() {
     override fun getAnimeUrl(anime: SAnime): String {
         val (type, id) = anime.url.split("-", limit = 2)
 
-        return preferences.webUIUrl.toHttpUrl().newBuilder()
+        return baseUrl.toHttpUrl().newBuilder()
             .fragment("/detail/$type/$id")
             .build().toString()
     }
@@ -471,7 +471,7 @@ class Stremio : Source() {
         val (type, id) = episode.url.split("-", limit = 2)
         val entryId = id.substringBefore(":")
 
-        return preferences.webUIUrl.toHttpUrl().newBuilder()
+        return baseUrl.toHttpUrl().newBuilder()
             .fragment("/detail/$type/$entryId/$id")
             .build().toString()
     }
@@ -634,36 +634,26 @@ class Stremio : Source() {
     // ============================ Preferences =============================
 
     private var SharedPreferences.authKey by authKeyDelegate
-
-    private val webUIDelegate = preferences.delegate(WEBUI_URL_KEY, WEBUI_URL_DEFAULT)
-    private val SharedPreferences.webUIUrl by webUIDelegate
-
-    private val serverUrlDelegate = preferences.delegate(SERVER_URL_KEY, SERVER_URL_DEFAULT)
-    private val SharedPreferences.serverUrl by serverUrlDelegate
-
-    private val emailDelegate = preferences.delegate(EMAIL_KEY, EMAIL_DEFAULT)
-    private val SharedPreferences.email by emailDelegate
-
-    private val passwordDelegate = preferences.delegate(PASSWORD_KEY, PASSWORD_DEFAULT)
-    private val SharedPreferences.password by passwordDelegate
-
-    private val nameTemplateDelegate = preferences.delegate(
+    private val SharedPreferences.webUIUrl by preferences.delegate(WEBUI_URL_KEY, WEBUI_URL_DEFAULT)
+    private val SharedPreferences.serverUrl by preferences.delegate(SERVER_URL_KEY, SERVER_URL_DEFAULT)
+    private val SharedPreferences.email by preferences.delegate(EMAIL_KEY, EMAIL_DEFAULT)
+    private val SharedPreferences.password by preferences.delegate(PASSWORD_KEY, PASSWORD_DEFAULT)
+    private val SharedPreferences.nameTemplate by preferences.delegate(
         PREF_EPISODE_NAME_TEMPLATE_KEY,
         PREF_EPISODE_NAME_TEMPLATE_DEFAULT,
     )
-    private val SharedPreferences.nameTemplate by nameTemplateDelegate
-
-    private val scanlatorTemplateDelegate = preferences.delegate(
+    private val SharedPreferences.scanlatorTemplate by preferences.delegate(
         PREF_SCANLATOR_NAME_TEMPLATE_KEY,
         PREF_SCANLATOR_NAME_TEMPLATE_DEFAULT,
     )
-    private val SharedPreferences.scanlatorTemplate by scanlatorTemplateDelegate
-
-    private val skipSeason0Delegate = preferences.delegate(PREF_SKIP_SEASON_0_KEY, PREF_SKIP_SEASON_0_DEFAULT)
-    private val SharedPreferences.skipSeason0 by skipSeason0Delegate
-
-    private val fetchLibraryDelegate = preferences.delegate(PREF_FETCH_LIBRARY_KEY, PREF_FETCH_LIBRARY_DEFAULT)
-    private val SharedPreferences.fetchLibrary by fetchLibraryDelegate
+    private val SharedPreferences.skipSeason0 by preferences.delegate(
+        PREF_SKIP_SEASON_0_KEY,
+        PREF_SKIP_SEASON_0_DEFAULT,
+    )
+    private val SharedPreferences.fetchLibrary by preferences.delegate(
+        PREF_FETCH_LIBRARY_KEY,
+        PREF_FETCH_LIBRARY_DEFAULT,
+    )
 
     private fun SharedPreferences.clearCredentials() {
         edit()
@@ -719,7 +709,6 @@ class Stremio : Source() {
             title = "Fetch library",
             summary = getLibrarySummary(preferences.authKey),
             enabled = preferences.authKey.isNotBlank(),
-            lazyDelegate = fetchLibraryDelegate,
         )
 
         val webUiSummary: (String) -> String = { it.ifBlank { "WebUI url (used only for WebView)" } }
@@ -733,10 +722,7 @@ class Stremio : Source() {
             inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_URI,
             validate = { it.toHttpUrlOrNull() != null && !it.endsWith("/") },
             validationMessage = { "The URL is invalid, malformed, or ends with a slash" },
-        ) {
-            baseUrl = it
-            webUIDelegate.updateValue(it)
-        }
+        ) { baseUrl = it }
 
         val serverUrlSummary: (String) -> String = { it.ifBlank { "Server url for torrent streams (optional)" } }
         screen.addEditTextPreference(
@@ -749,7 +735,6 @@ class Stremio : Source() {
             inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_URI,
             validate = { it.toHttpUrlOrNull() != null && !it.endsWith("/") },
             validationMessage = { "The URL is invalid, malformed, or ends with a slash" },
-            lazyDelegate = serverUrlDelegate,
         )
 
         val isValidAddon: (String) -> Boolean = {
@@ -771,7 +756,6 @@ class Stremio : Source() {
                 val invalidUrl = urls.firstOrNull { url -> !isValidAddon(url) } ?: it
                 "'$invalidUrl' is not a valid stremio addon"
             },
-            lazyDelegate = addonDelegate,
         )
 
         fun onCompleteLogin(result: Boolean) {
@@ -830,7 +814,6 @@ class Stremio : Source() {
             getSummary = emailSummary,
             dialogMessage = "Email address",
             inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS,
-            lazyDelegate = emailDelegate,
         ) {
             if (preferences.password.isNotBlank()) {
                 logIn()
@@ -847,7 +830,6 @@ class Stremio : Source() {
             summary = passwordSummary(preferences.password),
             getSummary = passwordSummary,
             inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD,
-            lazyDelegate = passwordDelegate,
         ) {
             if (preferences.email.isNotBlank()) {
                 logIn()
@@ -870,7 +852,6 @@ class Stremio : Source() {
                 }
             },
             validationMessage = { "Invalid episode name format" },
-            lazyDelegate = nameTemplateDelegate,
         )
 
         screen.addEditTextPreference(
@@ -889,7 +870,6 @@ class Stremio : Source() {
                 }
             },
             validationMessage = { "Invalid scanlator format" },
-            lazyDelegate = scanlatorTemplateDelegate,
         )
 
         screen.addSwitchPreference(
@@ -897,7 +877,6 @@ class Stremio : Source() {
             default = PREF_SKIP_SEASON_0_DEFAULT,
             title = "Skip season 0",
             summary = "Filter out specials",
-            lazyDelegate = skipSeason0Delegate,
         )
 
         screen.addPreference(logOutPref)

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/addon/AddonManager.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/addon/AddonManager.kt
@@ -78,8 +78,14 @@ class AddonManager(
                 authKeyValue.isNotBlank() -> getFromUser(thisRef, authKeyValue)
                 else -> throw Exception("Addons must be manually added if not logged in")
             }
-            cachedAddons = addonValue
-            cachedAuthKey = authKeyValue
+
+            if (useAddons) {
+                cachedAddons = addonValue
+                cachedAuthKey = null
+            } else {
+                cachedAuthKey = authKeyValue
+                cachedAddons = null
+            }
         }
 
         return addons ?: emptyList()

--- a/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/addon/AddonManager.kt
+++ b/src/all/stremio/src/eu/kanade/tachiyomi/animeextension/all/stremio/addon/AddonManager.kt
@@ -6,7 +6,7 @@ import eu.kanade.tachiyomi.animeextension.all.stremio.addon.dto.AddonDto
 import eu.kanade.tachiyomi.animeextension.all.stremio.addon.dto.AddonResultDto
 import eu.kanade.tachiyomi.animeextension.all.stremio.addon.dto.ManifestDto
 import eu.kanade.tachiyomi.util.parallelMapNotNull
-import extensions.utils.LazyMutablePreference
+import extensions.utils.PreferenceDelegate
 import extensions.utils.Source
 import extensions.utils.get
 import extensions.utils.parseAs
@@ -17,9 +17,9 @@ import kotlinx.serialization.json.put
 
 @Suppress("SpellCheckingInspection")
 class AddonManager(
-    addonDelegate: LazyMutablePreference<String>,
-    authKeyDelegate: LazyMutablePreference<String>,
-) {
+    addonDelegate: PreferenceDelegate<String>,
+    authKeyDelegate: PreferenceDelegate<String>,
+) /* KMK --> : ReadOnlyProperty<Source, List<AddonDto>> KMK <-- */ {
     private val addonValue by addonDelegate
     private val authKeyValue by authKeyDelegate
 
@@ -27,6 +27,11 @@ class AddonManager(
     private var cachedAuthKey: String? = null
     private var addons: List<AddonDto>? = null
 
+    /**
+     * The use of `runBlocking(Dispatchers.IO)` inside the `getValue` method of a property delegate is a potential performance hazard.
+     * This will block the thread that accesses the addons property while the addons are being fetched over the network.
+     * A safer approach would be to expose a suspend function [getAddons] to retrieve the addons.
+     */
     /* KMK -->
     override fun getValue(
         thisRef: Source,
@@ -49,8 +54,10 @@ class AddonManager(
 
             if (useAddons) {
                 cachedAddons = addonValue
+                cachedAuthKey = null
             } else {
                 cachedAuthKey = authKeyValue
+                cachedAddons = null
             }
         }
 


### PR DESCRIPTION
Address minor bugs and clean up the codebase, including updates to version codes for Stremio and Jellyfin. Additionally, add a Renovate configuration file for dependency management.

## Summary by Sourcery

Simplify and clean up preference delegation by renaming and refactoring LazyMutablePreference into PreferenceDelegate, update extension code to use the new delegate, fix Stremio URL construction, bump version codes, and introduce Renovate for automated dependency updates.

New Features:
- Add Renovate configuration for automated dependency updates

Bug Fixes:
- Use baseUrl instead of webUIUrl when constructing Stremio content URLs

Enhancements:
- Rename LazyMutablePreference to PreferenceDelegate and streamline preference get/set logic by removing unnecessary caching and synchronization
- Update Jellyfin and Stremio extensions to inline preference delegations and remove deprecated lazyDelegate parameters
- Refactor AddonManager to leverage PreferenceDelegate and correct credential caching behavior

Build:
- Bump Jellyfin version code from 28 to 29
- Bump Stremio version code from 6 to 7

CI:
- Add .github/renovate.json for dependency management