### PR TITLE
Fix AnimeLib sources

### DIFF
--- a/src/ru/animelib/build.gradle
+++ b/src/ru/animelib/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Animelib'
     extClass = '.Animelib'
-    extVersionCode = 8
+    extVersionCode = 9
     isNsfw = true
 }
 

--- a/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
+++ b/src/ru/animelib/src/eu/kanade/tachiyomi/animeextension/ru/animelib/Animelib.kt
@@ -39,9 +39,9 @@ class Animelib : ConfigurableAnimeSource, AnimeHttpSource() {
 
     override val supportsLatest = true
 
-    private val domain = "anilib.me"
+    private val domain = "v3.animelib.org"
     override val baseUrl = "https://$domain/ru"
-    private val apiUrl = "https://api.lib.social/api"
+    private val apiUrl = "https://api.cdnlibs.org/api"
 
     private val playlistUtils by lazy { PlaylistUtils(client, headers) }
     private val dateFormatter by lazy { SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH) }


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
- [x] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/aniyomi-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

---

Referenced: #259 #386

## Changelog: 
* Change domain (Because on the original site write "Access with `anilib.me` is no longer supported"). Proof: 
<img width="1080" height="478" alt="изображение" src="https://github.com/user-attachments/assets/6f5f494d-c2cf-448e-a433-500cd5cb9767" />


## Troubleshoots (in my tests):
* Not all thumbnails are loaded (If you try to open thumbnail manually, you get `403 - Forbidden `)
* Not all Anime opens (`Unable to resolve host`, or `video list is empty`)

<img width="360" height="840" alt="Not all thumbnails are loaded" src="https://github.com/user-attachments/assets/1f9c0eda-f620-46dd-ba76-6fd69ce71c5a" /><img width="360" height="840" alt="Unable to resolve host (Yakusoku no Neverland)" src="https://github.com/user-attachments/assets/ccef8d66-ff81-4a19-8c53-979a4ad6e2ae"/> <img width="360" height="840" alt="Video list is empty (One Piece)" src="https://github.com/user-attachments/assets/215b851b-76f1-4f9c-a7e3-a84035977329" />

