### PR TITLE
Update AnimeSaturn.kt

### DIFF
--- a/src/it/animesaturn/build.gradle
+++ b/src/it/animesaturn/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anime Saturn'
     extClass = '.AnimeSaturn'
-    extVersionCode = 10
+    extVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/it/animesaturn/src/eu/kanade/tachiyomi/animeextension/it/animesaturn/AnimeSaturn.kt
+++ b/src/it/animesaturn/src/eu/kanade/tachiyomi/animeextension/it/animesaturn/AnimeSaturn.kt
@@ -25,11 +25,11 @@ class AnimeSaturn : ConfigurableAnimeSource, ParsedAnimeHttpSource() {
     override val baseUrl by lazy {
         preferences.getString(
             "preferred_domain",
-            "https://anisaturn.com",
+            "https://anisaturn.cx",
         )!!
     }
 
-    private fun isNewDomain(): Boolean = baseUrl == "https://anisaturn.com"
+    private fun isNewDomain(): Boolean = baseUrl == "https://anisaturn.cx"
 
     override val lang = "it"
 


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
- [x] Have made sure all the icons are in png format

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/yuzono/aniyomi-extensions/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Switch AnimeSaturn extension to the updated anisaturn.cx domain

Bug Fixes:
- Update default baseUrl from anisaturn.com to anisaturn.cx
- Adjust isNewDomain check to use anisaturn.cx