### PR TITLE
fix(it/AnimeSaturn): update domain & refactor preference handling

### DIFF
--- a/src/it/animesaturn/build.gradle
+++ b/src/it/animesaturn/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Anime Saturn'
     extClass = '.AnimeSaturn'
-    extVersionCode = 10
+    extVersionCode = 11
 }
 
 apply from: "$rootDir/common.gradle"


### PR DESCRIPTION
Update the domain handling logic and refactor preference management to improve clarity and maintainability. The changes ensure that the application defaults to a valid domain and simplifies the setup of preferences.

## Summary by Sourcery

Refactor AnimeSaturn source to centralize and simplify preference setup and domain handling using extension utilities and delegates.

Bug Fixes:
- Validate and reset invalid domain preferences at startup to ensure a valid default domain

Enhancements:
- Replace manual ListPreference creation with addListPreference extension for video quality and domain options
- Introduce companion object constants for preference keys, entries, and default values
- Use delegated preference property for baseUrl and consolidate preference initialization with getPreferencesLazy